### PR TITLE
Code modifications for QC 2024 PbPb

### DIFF
--- a/Jets/JetQC.C
+++ b/Jets/JetQC.C
@@ -183,7 +183,11 @@ void JetQC() {
 
     // Draw_Eta_DatasetComparison(jetRadiusForDataComp, ptRange, "normEvents");
     // Draw_Eta_DatasetComparison(jetRadiusForDataComp, ptRange, "normEntries");
+<<<<<<< HEAD
+    // Draw_Phi_DatasetComparison(jetRadiusForDataComp, ptRange, "normEvents");
+=======
     Draw_Phi_DatasetComparison(jetRadiusForDataComp, ptRange, "normEvents");
+>>>>>>> 8af6bc2 (adding ratio plots in JetQC and legends in Tracks)
 
     // Draw_Constituent_Pt_DatasetComparison(ptRange, jetRadiusForDataComp);
 
@@ -479,7 +483,7 @@ void Draw_Eta_RadiusComparison(int iDataset, float* PtRange) {
     H1D_jetEta[iRadius] = (TH1D*)H3D_jetRjetPtjetEta->ProjectionZ("jetEta_"+RadiusLegend[iRadius]+Form("%.1f", PtCutLow)+"<pt<"+Form("%.1f", PtCutHigh), ibinJetRadius, ibinJetRadius, ibinPt_low, ibinPt_high, "e");
     H1D_jetEta_rebinned[iRadius] = (TH1D*)H1D_jetEta[iRadius]->Rebin(1.,"jetEta_rebinned_"+RadiusLegend[iRadius]+Form("%.1f", PtCutLow)+"<pt<"+Form("%.1f", PtCutHigh));
 
-    NormaliseYieldToIntegral(H1D_jetEta_rebinned[iRadius]);    
+    NormaliseYieldToIntegral(H1D_jetEta_rebinned[iRadius]);
     // NormaliseYieldToNEvents(H1D_jetEta_rebinned[iRadius], GetNEventsSelected_JetFramework(file_O2Analysis_list[iDataset], analysisWorkflow[iDataset]));
   }
 

--- a/Jets/JetQC.C
+++ b/Jets/JetQC.C
@@ -860,7 +860,8 @@ void Draw_Pt_DatasetComparison(float* etaRange, std::string options, float jetRa
   Draw_TH1_Histograms(H1D_jetPt_rebinned, DatasetsNames, nDatasets, textContext, pdfName, iJetFinderQaType == 0 ? texPtJetRawX : texPtJetBkgCorrX, texJetPtYield_EventNorm, texCollisionDataInfo, drawnWindow, legendPlacement, contextPlacementAuto, "logy"+histDatasetComparisonStructure);
   if (divideSuccess == true) {
     if (histDatasetComparisonStructure.find("twoByTwoDatasetPairs") != std::string::npos) {
-      Draw_TH1_Histograms(H1D_jetPt_rebinned_ratios, DatasetsNamesPairRatio, nHistPairRatio, textContext, pdfName_ratio, iJetFinderQaType == 0 ? texPtJetRawX : texPtJetBkgCorrX, texRatio, texCollisionDataInfo, drawnWindowZoomTwoByTwo, legendPlacementRatio, contextPlacementAuto, "zoomToOneMedium1");
+      Draw_TH1_Histograms(H1D_jetPt_rebinned_ratios, DatasetsNamesPairRatio, nHistPairRatio, textContext, pdfName_ratio, iJetFinderQaType == 0 ? texPtJetRawX : texPtJetBkgCorrX, texRatio, texCollisionDataInfo, drawnWindowAuto, legendPlacementRatio, contextPlacementAuto);
+      Draw_TH1_Histograms(H1D_jetPt_rebinned_ratios, DatasetsNamesPairRatio, nHistPairRatio, textContext, pdfName_ratio_zoom, iJetFinderQaType == 0 ? texPtJetRawX : texPtJetBkgCorrX, texRatio, texCollisionDataInfo, drawnWindowZoomTwoByTwo, legendPlacementRatio, contextPlacementAuto);
     } else {
     Draw_TH1_Histograms(H1D_jetPt_rebinned_ratios, DatasetsNames, nDatasets, textContext, pdfName_ratio, iJetFinderQaType == 0 ? texPtJetRawX : texPtJetBkgCorrX, texRatioDatasets, texCollisionDataInfo, drawnWindow, legendPlacementRatio, contextPlacementAuto, "noMarkerFirst"+histDatasetComparisonStructure);
     Draw_TH1_Histograms(H1D_jetPt_rebinned_ratios, DatasetsNames, nDatasets, textContext, pdfName_ratio_zoom, iJetFinderQaType == 0 ? texPtJetRawX : texPtJetBkgCorrX, texRatioDatasets, texCollisionDataInfo, drawnWindowZoom, legendPlacementAuto, contextPlacementAuto, "noMarkerFirst");
@@ -968,6 +969,7 @@ void Draw_Eta_DatasetComparison(float jetRadius, float* PtRange, std::string opt
 
   TString* pdfName = new TString("jet_"+jetType[iJetType]+"_"+jetLevel[iJetLevel]+"_DataComp_R="+Form("%.1f", jetRadius)+"_Eta_@pT["+Form("%03.0f", PtCutLow)+","+Form("%03.0f", PtCutHigh)+"]"+jetFinderQaHistType[iJetFinderQaType]+"_"+(TString)pdfNameNorm);
   TString* pdfName_ratio = new TString("jet_"+jetType[iJetType]+"_"+jetLevel[iJetLevel]+"_DataComp_R="+Form("%.1f", jetRadius)+"_Eta_@pT["+Form("%03.0f", PtCutLow)+","+Form("%03.0f", PtCutHigh)+"]"+jetFinderQaHistType[iJetFinderQaType]+"_"+(TString)pdfNameNorm+"_ratio");
+  TString* pdfName_ratio_zoom = new TString("jet_"+jetType[iJetType]+"_"+jetLevel[iJetLevel]+"_DataComp_R="+Form("%.1f", jetRadius)+"_Eta_@pT["+Form("%03.0f", PtCutLow)+","+Form("%03.0f", PtCutHigh)+"]"+jetFinderQaHistType[iJetFinderQaType]+"_"+(TString)pdfNameNorm+"_ratio_zoom");
 
   // TString textContext(contextDatasetCompAndRadiusAndVarRange(jetRadius, PtRange, "pt"));
   TString textContext(contextCustomThreeFields(*texDatasetsComparisonCommonDenominator, "", "#splitline{"+contextJetRadius(jetRadius)+"}{"+contextPtRange(PtRange)+"}", ""));
@@ -981,7 +983,9 @@ void Draw_Eta_DatasetComparison(float jetRadius, float* PtRange, std::string opt
 
   if (divideSuccess == true) {
     if (histDatasetComparisonStructure.find("twoByTwoDatasetPairs") != std::string::npos) {
-      Draw_TH1_Histograms(H1D_jetEta_rebinned_ratios, DatasetsNamesPairRatio, nHistPairRatio, textContext, pdfName_ratio, texEtaX, texRatio, texCollisionDataInfo, drawnWindowZoomTwoByTwo, legendPlacementRatio, contextPlacementAuto, "zoomToOneMedium1");
+      Draw_TH1_Histograms(H1D_jetEta_rebinned_ratios, DatasetsNamesPairRatio, nHistPairRatio, textContext, pdfName_ratio, texEtaX, texRatio, texCollisionDataInfo, drawnWindowAuto, legendPlacementRatio, contextPlacementAuto);
+      Draw_TH1_Histograms(H1D_jetEta_rebinned_ratios, DatasetsNamesPairRatio, nHistPairRatio, textContext, pdfName_ratio_zoom, texEtaX, texRatio, texCollisionDataInfo, drawnWindowZoomTwoByTwo, legendPlacementRatio, contextPlacementAuto);
+
     } 
     else {
       Draw_TH1_Histograms(H1D_jetEta_rebinned_ratios, DatasetsNames, nDatasets, textContext, pdfName_ratio, texEtaX, texRatioDatasets, texCollisionDataInfo, drawnWindow, legendPlacement, contextPlacementAuto, "noMarkerFirst"+histDatasetComparisonStructure);

--- a/Jets/JetQC.C
+++ b/Jets/JetQC.C
@@ -154,19 +154,19 @@ void JetQC() {
   // const int nPtMinCuts = 7;
   // float jetPtMinCut;
   // float jetPtMinCutArray[nPtMinCuts] = {-999, 0, 5, 10, 15, 20, 40.};
-  // const int nPtBins = 5;
-  // float jetPtMinCut, jetPtMaxCut;
-  // float jetPtMinCutArray[nPtBins+1] = {0.15, 10, 20, 40, 60, 200};
-  const int nPtBins = 1;
+  const int nPtBins = 5;
   float jetPtMinCut, jetPtMaxCut;
-  float jetPtMinCutArray[nPtBins+1] = {0.15, 200};
+  float jetPtMinCutArray[nPtBins+1] = {0.15, 10, 20, 40, 60, 200};
+  // const int nPtBins = 1;
+  // float jetPtMinCut, jetPtMaxCut;
+  // float jetPtMinCutArray[nPtBins+1] = {0.15, 200};
 
 
   // only for leading pT analysis, those two are a bit hardcoded
   // Draw_PtPeakPosition_vs_leadTrackCut(etaRangeSym, jetRadiusForDataComp);
   // Draw_PtLeadCutStudy_PtOfRatio1(etaRangeSym, "", jetRadiusForDataComp);
 
-  Draw_Pt_DatasetComparison(etaRangeSym, "normEvents", jetRadiusForDataComp);
+  // Draw_Pt_DatasetComparison(etaRangeSym, "normEvents", jetRadiusForDataComp);
   // Draw_Pt_DatasetComparison_withRun2RitsuyaHardcoded(etaRangeSym, "normEvents", jetRadiusForDataComp);
   for(int iPtBin = 0; iPtBin < nPtBins; iPtBin++){
     jetPtMinCut = jetPtMinCutArray[iPtBin];
@@ -183,7 +183,7 @@ void JetQC() {
 
     // Draw_Eta_DatasetComparison(jetRadiusForDataComp, ptRange, "normEvents");
     // Draw_Eta_DatasetComparison(jetRadiusForDataComp, ptRange, "normEntries");
-    // Draw_Phi_DatasetComparison(jetRadiusForDataComp, ptRange, "normEvents");
+    Draw_Phi_DatasetComparison(jetRadiusForDataComp, ptRange, "normEvents");
 
     // Draw_Constituent_Pt_DatasetComparison(ptRange, jetRadiusForDataComp);
 
@@ -479,7 +479,7 @@ void Draw_Eta_RadiusComparison(int iDataset, float* PtRange) {
     H1D_jetEta[iRadius] = (TH1D*)H3D_jetRjetPtjetEta->ProjectionZ("jetEta_"+RadiusLegend[iRadius]+Form("%.1f", PtCutLow)+"<pt<"+Form("%.1f", PtCutHigh), ibinJetRadius, ibinJetRadius, ibinPt_low, ibinPt_high, "e");
     H1D_jetEta_rebinned[iRadius] = (TH1D*)H1D_jetEta[iRadius]->Rebin(1.,"jetEta_rebinned_"+RadiusLegend[iRadius]+Form("%.1f", PtCutLow)+"<pt<"+Form("%.1f", PtCutHigh));
 
-    NormaliseYieldToIntegral(H1D_jetEta_rebinned[iRadius]);
+    NormaliseYieldToNEntries(H1D_jetEta_rebinned[iRadius]);
     // NormaliseYieldToNEvents(H1D_jetEta_rebinned[iRadius], GetNEventsSelected_JetFramework(file_O2Analysis_list[iDataset], analysisWorkflow[iDataset]));
   }
 
@@ -800,13 +800,13 @@ void Draw_Pt_DatasetComparison(float* etaRange, std::string options, float jetRa
     // H1D_jetPt_rebinned[iDataset] = (TH1D*)H1D_jetPt[iDataset]->Rebin(5.,"jetPt_rebinned_"+Datasets[iDataset]+DatasetsNames[iDataset]+"Radius"+Form("%.1f",jetRadius)+Form("%.1f", EtaCutLow)+"<eta<"+Form("%.1f", EtaCutHigh));
 
 
-    // int nBinPtJets = 16;
-    // double ptBinsJets[17] = {-10., -5., 0., 5., 10., 15., 20., 25., 30., 35., 40., 50., 60., 80., 100., 140., 200.};
-    H1D_jetPt_rebinned[iDataset] = (TH1D*)H1D_jetPt[iDataset]->Rebin(1. ,"jetPt_rebinned_"+Datasets[iDataset]+DatasetsNames[iDataset]+"Radius"+Form("%.1f",jetRadius)+Form("%.1f", EtaCutLow)+"<eta<"+Form("%.1f", EtaCutHigh));
+    int nBinPtJets = 16;
+    double ptBinsJets[17] = {-10., -5., 0., 5., 10., 15., 20., 25., 30., 35., 40., 50., 60., 80., 100., 140., 200.};
+    H1D_jetPt_rebinned[iDataset] = (TH1D*)H1D_jetPt[iDataset]->Rebin(nBinPtJets,"jetPt_rebinned_"+Datasets[iDataset]+DatasetsNames[iDataset]+"Radius"+Form("%.1f",jetRadius)+Form("%.1f", EtaCutLow)+"<eta<"+Form("%.1f", EtaCutHigh), ptBinsJets);
 
 
     if (options.find("normEntries") != std::string::npos) {
-      NormaliseYieldToIntegral(H1D_jetPt_rebinned[iDataset]);
+      NormaliseYieldToNEntries(H1D_jetPt_rebinned[iDataset]);
       yAxisLabel = texJetPtYield_EntriesNorm;
     }
     double Nevents;
@@ -849,9 +849,9 @@ void Draw_Pt_DatasetComparison(float* etaRange, std::string options, float jetRa
   // TString textContext(contextDatasetCompAndRadiusAndVarRange(jetRadius, etaRange, "eta"));
   TString textContext(contextCustomThreeFields(*texDatasetsComparisonCommonDenominator, "", "#splitline{"+contextJetRadius(jetRadius)+"}{"+contextEtaRange(etaRange)+"}", ""));
 
-  std::array<std::array<float, 2>, 2> drawnWindow = {{{-25, 200},{10E-9, 40}}};
+  std::array<std::array<float, 2>, 2> drawnWindow = {{{-25, 200},{-999, -999}}};
   std::array<std::array<float, 2>, 2> drawnWindowZoom = {{{-10, 200},{0.6, 1.6}}};
-
+  std::array<std::array<float, 2>, 2> drawnWindowZoomTwoByTwo = {{{-25, 200},{0.5, 2}}};
   std::array<std::array<float, 2>, 2> legendPlacement = {{{0.65, 0.6}, {0.85, 0.85}}}; // {{{x1, y1}, {x2, y2}}}
   std::array<std::array<float, 2>, 2> legendPlacementRatio = {{{0.6, 0.2}, {0.8, 0.45}}}; // {{{x1, y1}, {x2, y2}}}
   // std::array<std::array<float, 2>, 2> legendPlacementAuto = {{{-999, -999}, {-999, -999}}}; // {{{x1, y1}, {x2, y2}}}
@@ -859,7 +859,7 @@ void Draw_Pt_DatasetComparison(float* etaRange, std::string options, float jetRa
   Draw_TH1_Histograms(H1D_jetPt_rebinned, DatasetsNames, nDatasets, textContext, pdfName, iJetFinderQaType == 0 ? texPtJetRawX : texPtJetBkgCorrX, texJetPtYield_EventNorm, texCollisionDataInfo, drawnWindow, legendPlacement, contextPlacementAuto, "logy"+histDatasetComparisonStructure);
   if (divideSuccess == true) {
     if (histDatasetComparisonStructure.find("twoByTwoDatasetPairs") != std::string::npos) {
-      Draw_TH1_Histograms(H1D_jetPt_rebinned_ratios, DatasetsNamesPairRatio, nHistPairRatio, textContext, pdfName_ratio, iJetFinderQaType == 0 ? texPtJetRawX : texPtJetBkgCorrX, texRatio, texCollisionDataInfo, drawnWindow, legendPlacementRatio, contextPlacementAuto, "zoomToOneMedium1");
+      Draw_TH1_Histograms(H1D_jetPt_rebinned_ratios, DatasetsNamesPairRatio, nHistPairRatio, textContext, pdfName_ratio, iJetFinderQaType == 0 ? texPtJetRawX : texPtJetBkgCorrX, texRatio, texCollisionDataInfo, drawnWindowZoomTwoByTwo, legendPlacementRatio, contextPlacementAuto, "zoomToOneMedium1");
     } else {
     Draw_TH1_Histograms(H1D_jetPt_rebinned_ratios, DatasetsNames, nDatasets, textContext, pdfName_ratio, iJetFinderQaType == 0 ? texPtJetRawX : texPtJetBkgCorrX, texRatioDatasets, texCollisionDataInfo, drawnWindow, legendPlacementRatio, contextPlacementAuto, "noMarkerFirst"+histDatasetComparisonStructure);
     Draw_TH1_Histograms(H1D_jetPt_rebinned_ratios, DatasetsNames, nDatasets, textContext, pdfName_ratio_zoom, iJetFinderQaType == 0 ? texPtJetRawX : texPtJetBkgCorrX, texRatioDatasets, texCollisionDataInfo, drawnWindowZoom, legendPlacementAuto, contextPlacementAuto, "noMarkerFirst");
@@ -919,16 +919,19 @@ void Draw_Eta_DatasetComparison(float jetRadius, float* PtRange, std::string opt
       cout << "Requested workflow is incorrect: it should be jet-finder-charged-qa or jet-spectra-charged" << endl;
     }
 
+
+    H1D_jetEta_rebinned[iDataset] = (TH1D*)H1D_jetEta[iDataset]->Rebin(5.,"jetEta_rebinned_"+Datasets[iDataset]+DatasetsNames[iDataset]+"Radius"+Form("%.1f",jetRadius)+Form("%.1f", PtCutLow)+"<pt<"+Form("%.1f", PtCutHigh));
+    cout << "getentries H3D = "<< H3D_jetRjetPtjetEta[iDataset]->GetEntries() << endl;
+    cout << "getentries H1D = "<< H1D_jetEta_rebinned[iDataset]->GetEntries() << endl;
+
     if (PtRange[0] < 40) {
       H1D_jetEta_rebinned[iDataset] = (TH1D*)H1D_jetEta[iDataset]->Rebin(5.,"jetEta_rebinned_"+Datasets[iDataset]+DatasetsNames[iDataset]+"Radius"+Form("%.1f",jetRadius)+Form("%.1f", PtCutLow)+"<pt<"+Form("%.1f", PtCutHigh));
     } else {
       H1D_jetEta_rebinned[iDataset] = (TH1D*)H1D_jetEta[iDataset]->Rebin(20.,"jetEta_rebinned_"+Datasets[iDataset]+DatasetsNames[iDataset]+"Radius"+Form("%.1f",jetRadius)+Form("%.1f", PtCutLow)+"<pt<"+Form("%.1f", PtCutHigh));
     }
-    cout << "getentries H3D = "<< H3D_jetRjetPtjetEta[iDataset]->GetEntries() << endl;
-    cout << "getentries H1D = "<< H1D_jetEta_rebinned[iDataset]->GetEntries() << endl;
 
     if (options.find("normEntries") != std::string::npos) {
-      NormaliseYieldToIntegral(H1D_jetEta_rebinned[iDataset]);
+      NormaliseYieldToNEntries(H1D_jetEta_rebinned[iDataset]);
       yAxisLabel = texJetEtaYield_EntriesNorm;
       pdfNameNorm = "normEntries";
     }
@@ -944,9 +947,25 @@ void Draw_Eta_DatasetComparison(float jetRadius, float* PtRange, std::string opt
       pdfNameNorm = "normEvents";
     }
 
-    H1D_jetEta_rebinned_ratios[iDataset] = (TH1D*)H1D_jetEta_rebinned[iDataset]->Clone("jetEta_rebinned_ratios"+Datasets[iDataset]+DatasetsNames[iDataset]+"Radius"+Form("%.1f",jetRadius)+Form("%.1f", PtCutLow)+"<pt<"+Form("%.1f", PtCutHigh));
-    H1D_jetEta_rebinned_ratios[iDataset]->Reset("M");
-    divideSuccess = H1D_jetEta_rebinned_ratios[iDataset]->Divide(H1D_jetEta_rebinned[iDataset], H1D_jetEta_rebinned[0], 1., 1., datasetsAreSubsetsofId0 ? "b" : "");
+  
+  }
+
+  TString DatasetsNamesPairRatio[nDatasets];
+  int nHistPairRatio = (int)nDatasets / 2;
+  for(int iDataset = 0; iDataset < nDatasets; iDataset++){
+    if (histDatasetComparisonStructure.find("twoByTwoDatasetPairs") != std::string::npos) { //twoByTwoDatasetPairs assumes a Datasets array like so: {pair1_element1, pair2_element1, ..., pairN_element1, pair1_element2, pair2_element2, ..., pairN_element2}
+      if (iDataset < nHistPairRatio) {
+        DatasetsNamesPairRatio[iDataset] = DatasetsNames[2*iDataset]+(TString)"/"+DatasetsNames[2*iDataset+1];
+        H1D_jetEta_rebinned_ratios[iDataset] = (TH1D*)H1D_jetEta_rebinned[2*iDataset]->Clone("jetEta_rebinned_ratios"+Datasets[2*iDataset]+DatasetsNames[2*iDataset]+"Radius"+Form("%.1f",jetRadius)+Form("%.1f", PtCutLow)+"<pt<"+Form("%.1f", PtCutHigh));
+        H1D_jetEta_rebinned_ratios[iDataset]->Reset("M");
+        divideSuccess = H1D_jetEta_rebinned_ratios[iDataset]->Divide(H1D_jetEta_rebinned[2*iDataset], H1D_jetEta_rebinned[2*iDataset+1], 1., 1., datasetsAreSubsetsofId0 ? "b" : "");
+      }
+    } else {
+      H1D_jetEta_rebinned_ratios[iDataset] = (TH1D*)H1D_jetEta_rebinned[iDataset]->Clone("jetEta_rebinned_ratios"+Datasets[iDataset]+DatasetsNames[iDataset]+"Radius"+Form("%.1f",jetRadius)+Form("%.1f", PtCutLow)+"<pt<"+Form("%.1f", PtCutHigh));
+      H1D_jetEta_rebinned_ratios[iDataset]->Reset("M");
+      divideSuccess = H1D_jetEta_rebinned_ratios[iDataset]->Divide(H1D_jetEta_rebinned[iDataset], H1D_jetEta_rebinned[0], 1., 1., datasetsAreSubsetsofId0 ? "b" : "");
+
+    }
   }
 
   TString* pdfName = new TString("jet_"+jetType[iJetType]+"_"+jetLevel[iJetLevel]+"_DataComp_R="+Form("%.1f", jetRadius)+"_Eta_@pT["+Form("%03.0f", PtCutLow)+","+Form("%03.0f", PtCutHigh)+"]"+jetFinderQaHistType[iJetFinderQaType]+"_"+(TString)pdfNameNorm);
@@ -957,19 +976,27 @@ void Draw_Eta_DatasetComparison(float jetRadius, float* PtRange, std::string opt
 
   const std::array<std::array<float, 2>, 2> drawnWindow = {{{-1, 1}, {-999, -999}}}; // {{xmin, xmax}, {ymin, ymax}}
   const std::array<std::array<float, 2>, 2> legendPlacement = {{{0.65, 0.2}, {0.85, 0.45}}}; // xLeftLegend, yLowLegend, xRightLegend, yUpLegend
+  std::array<std::array<float, 2>, 2> drawnWindowZoomTwoByTwo = {{{-1, 1},{0.5, 2}}};
+  std::array<std::array<float, 2>, 2> legendPlacementRatio = {{{0.5, 0.2}, {0.7, 0.4}}}; // {{{x1, y1}, {x2, y2}}}
 
   Draw_TH1_Histograms(H1D_jetEta_rebinned, DatasetsNames, nDatasets, textContext, pdfName, texEtaX, yAxisLabel, texCollisionDataInfo, drawnWindow, legendPlacement, contextPlacementAuto, "");
 
   if (divideSuccess == true) {
-    Draw_TH1_Histograms(H1D_jetEta_rebinned_ratios, DatasetsNames, nDatasets, textContext, pdfName_ratio, texEtaX, texRatioDatasets, texCollisionDataInfo, drawnWindow, legendPlacement, contextPlacementAuto, "noMarkerFirst"+histDatasetComparisonStructure);
-  }
+    if (histDatasetComparisonStructure.find("twoByTwoDatasetPairs") != std::string::npos) {
+      Draw_TH1_Histograms(H1D_jetEta_rebinned_ratios, DatasetsNamesPairRatio, nHistPairRatio, textContext, pdfName_ratio, texEtaX, texRatio, texCollisionDataInfo, drawnWindowZoomTwoByTwo, legendPlacementRatio, contextPlacementAuto, "zoomToOneMedium1");
+    } 
+    else {
+      Draw_TH1_Histograms(H1D_jetEta_rebinned_ratios, DatasetsNames, nDatasets, textContext, pdfName_ratio, texEtaX, texRatioDatasets, texCollisionDataInfo, drawnWindow, legendPlacement, contextPlacementAuto, "noMarkerFirst"+histDatasetComparisonStructure);
+    }
+  }  
   else {
     cout << "Divide failed in Draw_Eta_DatasetComparison" << endl;
   }
+  
+
 }
 
 void Draw_Phi_DatasetComparison(float jetRadius, float* PtRange, std::string options) {
-
   TH3D* H3D_jetRjetPtjetPhi[nDatasets];
   TH1D* H1D_jetPhi[nDatasets];
   TH1D* H1D_jetPhi_rebinned[nDatasets];
@@ -985,7 +1012,6 @@ void Draw_Phi_DatasetComparison(float jetRadius, float* PtRange, std::string opt
   TString* yAxisLabel;
 
   for(int iDataset = 0; iDataset < nDatasets; iDataset++){
-
     if (analysisWorkflow[iDataset].Contains("jet-finder-charged-qa") == true) {
       H3D_jetRjetPtjetPhi[iDataset] = (TH3D*)((TH3D*)file_O2Analysis_list[iDataset]->Get(analysisWorkflow[iDataset]+"/h3_jet_r_jet_pt_jet_eta"+jetFinderQaHistType[iJetFinderQaType]))->Clone("Draw_Phi_DatasetComparison"+Datasets[iDataset]+DatasetsNames[iDataset]+"Radius"+Form("%.1f",jetRadius)+jetRadius+Form("%.1f", PtRange[0])+"<pt<"+Form("%.1f", PtRange[1]));
 
@@ -1018,7 +1044,7 @@ void Draw_Phi_DatasetComparison(float jetRadius, float* PtRange, std::string opt
     H1D_jetPhi_rebinned[iDataset] = (TH1D*)H1D_jetPhi[iDataset]->Rebin(5.,"jetPhi_rebinned_"+Datasets[iDataset]+DatasetsNames[iDataset]+"Radius"+Form("%.1f",jetRadius)+Form("%.1f", PtCutLow)+"<pt<"+Form("%.1f", PtCutHigh));
 
     if (options.find("normEntries") != std::string::npos) {
-      NormaliseYieldToIntegral(H1D_jetPhi_rebinned[iDataset]);
+      NormaliseYieldToNEntries(H1D_jetPhi_rebinned[iDataset]);
       yAxisLabel = texJetPhiYield_EntriesNorm;
     }
     double Nevents;
@@ -1032,10 +1058,28 @@ void Draw_Phi_DatasetComparison(float jetRadius, float* PtRange, std::string opt
       yAxisLabel = texJetPhiYield_EventNorm;
     }
 
-    H1D_jetPhi_rebinned_ratios[iDataset] = (TH1D*)H1D_jetPhi_rebinned[iDataset]->Clone("jetPhi_rebinned_ratios"+Datasets[iDataset]+DatasetsNames[iDataset]+"Radius"+Form("%.1f",jetRadius)+Form("%.1f", PtCutLow)+"<pt<"+Form("%.1f", PtCutHigh));
-    H1D_jetPhi_rebinned_ratios[iDataset]->Reset("M");
-    divideSuccess = H1D_jetPhi_rebinned_ratios[iDataset]->Divide(H1D_jetPhi_rebinned[iDataset], H1D_jetPhi_rebinned[0], 1., 1., datasetsAreSubsetsofId0 ? "b" : "");
+    
   }
+
+
+  TString DatasetsNamesPairRatio[nDatasets];
+  int nHistPairRatio = (int)nDatasets / 2;
+  for(int iDataset = 0; iDataset < nDatasets; iDataset++){
+    if (histDatasetComparisonStructure.find("twoByTwoDatasetPairs") != std::string::npos) { //twoByTwoDatasetPairs assumes a Datasets array like so: {pair1_element1, pair2_element1, ..., pairN_element1, pair1_element2, pair2_element2, ..., pairN_element2}
+      if (iDataset < nHistPairRatio) {
+        DatasetsNamesPairRatio[iDataset] = DatasetsNames[2*iDataset]+(TString)"/"+DatasetsNames[2*iDataset+1];
+        H1D_jetPhi_rebinned_ratios[iDataset] = (TH1D*)H1D_jetPhi_rebinned[2*iDataset]->Clone("jetPhi_rebinned_ratios"+Datasets[2*iDataset]+DatasetsNames[2*iDataset]+"Radius"+Form("%.1f",jetRadius)+Form("%.1f", PtCutLow)+"<pt<"+Form("%.1f", PtCutHigh));
+        H1D_jetPhi_rebinned_ratios[iDataset]->Reset("M");
+        divideSuccess = H1D_jetPhi_rebinned_ratios[iDataset]->Divide(H1D_jetPhi_rebinned[2*iDataset], H1D_jetPhi_rebinned[2*iDataset+1], 1., 1., datasetsAreSubsetsofId0 ? "b" : "");
+      }
+    } else {
+      H1D_jetPhi_rebinned_ratios[iDataset] = (TH1D*)H1D_jetPhi_rebinned[iDataset]->Clone("jetPhi_rebinned_ratios"+Datasets[iDataset]+DatasetsNames[iDataset]+"Radius"+Form("%.1f",jetRadius)+Form("%.1f", PtCutLow)+"<pt<"+Form("%.1f", PtCutHigh));
+      H1D_jetPhi_rebinned_ratios[iDataset]->Reset("M");
+      divideSuccess = H1D_jetPhi_rebinned_ratios[iDataset]->Divide(H1D_jetPhi_rebinned[iDataset], H1D_jetPhi_rebinned[0], 1., 1., datasetsAreSubsetsofId0 ? "b" : "");
+
+    }
+  }
+
 
   TString* pdfName = new TString("jet_"+jetType[iJetType]+"_"+jetLevel[iJetLevel]+"_DataComp_R="+Form("%.1f", jetRadius)+"_Phi_@pT["+Form("%03.0f", PtCutLow)+","+Form("%03.0f", PtCutHigh)+"]"+jetFinderQaHistType[iJetFinderQaType]);
   TString* pdfName_ratio = new TString("jet_"+jetType[iJetType]+"_"+jetLevel[iJetLevel]+"_DataComp_R="+Form("%.1f", jetRadius)+"_Phi_@pT["+Form("%03.0f", PtCutLow)+","+Form("%03.0f", PtCutHigh)+"]"+jetFinderQaHistType[iJetFinderQaType]+"_ratio");
@@ -1045,11 +1089,18 @@ void Draw_Phi_DatasetComparison(float jetRadius, float* PtRange, std::string opt
 
   const std::array<std::array<float, 2>, 2> drawnWindowRatioCustom = {{{-999, -999}, {0, 1.9}}}; // {{xmin, xmax}, {ymin, ymax}}
   std::array<std::array<float, 2>, 2> legendPlacementCustom = {{{0.2, 0.2}, {0.4, 0.45}}}; // {{{x1, y1}, {x2, y2}}}
+  std::array<std::array<float, 2>, 2> drawnWindowZoomTwoByTwo = {{{-1, 7},{0.5, 2}}};
+  std::array<std::array<float, 2>, 2> legendPlacementRatio = {{{0.5, 0.5}, {0.7, 0.7}}}; // {{{x1, y1}, {x2, y2}}}
 
   Draw_TH1_Histograms(H1D_jetPhi_rebinned, DatasetsNames, nDatasets, textContext, pdfName, texPhiX, texJetPhiYield_EventNorm, texCollisionDataInfo, drawnWindowAuto, legendPlacementCustom, contextPlacementAuto, "histWithLine");
 
   if (divideSuccess == true) {
+    if (histDatasetComparisonStructure.find("twoByTwoDatasetPairs") != std::string::npos) {
+      Draw_TH1_Histograms(H1D_jetPhi_rebinned_ratios, DatasetsNamesPairRatio, nHistPairRatio, textContext, pdfName_ratio, texPhiX, texRatio, texCollisionDataInfo, drawnWindowZoomTwoByTwo, legendPlacementRatio, contextPlacementAuto, "zoomToOneMedium1");
+    } 
+    else{
     Draw_TH1_Histograms(H1D_jetPhi_rebinned_ratios, DatasetsNames, nDatasets, textContext, pdfName_ratio, texPhiX, texRatioDatasets, texCollisionDataInfo, drawnWindowRatioCustom, legendPlacementCustom, contextPlacementAuto, "noMarkerFirst"+histDatasetComparisonStructure);
+    }
   }
   else {
     cout << "Divide failed in Draw_Phi_DatasetComparison" << endl;
@@ -1770,7 +1821,7 @@ void Draw_Eta_CentralityComparison(float jetRadius, int iDataset) { //for now on
     H1D_jetEta_rebinned[iCentralityBin] = (TH1D*)H1D_jetEta[iCentralityBin]->Rebin(1.,"jetEta_rebinned_"+Datasets[iDataset]+DatasetsNames[iDataset]+Form("%.1f", jetRadius)+"_@cent["+Form("%.1d", ibinCent_low)+","+Form("%.1d", ibinCent_high)+"]");
 
     H1D_jetEta_rebinned_entriesnorm[iCentralityBin] = (TH1D*)H1D_jetEta_rebinned[iCentralityBin]->Clone("jetEta_rebinned_"+Datasets[iDataset]+DatasetsNames[iDataset]+Form("%.1f", jetRadius)+"_@cent["+Form("%.1d", ibinCent_low)+","+Form("%.1d", ibinCent_high)+"]_entriesNorm");
-    NormaliseYieldToIntegral(H1D_jetEta_rebinned_entriesnorm[iCentralityBin]);
+    NormaliseYieldToNEntries(H1D_jetEta_rebinned_entriesnorm[iCentralityBin]);
 
     NormaliseYieldToNEvents(H1D_jetEta_rebinned[iCentralityBin], GetNEventsSelectedCentrality_JetFramework(file_O2Analysis_list[iDataset], analysisWorkflow[iDataset], arrayCentralityBinning[iCentralityBin], arrayCentralityBinning[iCentralityBin+1]));
 
@@ -1818,7 +1869,7 @@ void Draw_Phi_CentralityComparison(float jetRadius, int iDataset) { //for now on
     H1D_jetPhi_rebinned[iCentralityBin] = (TH1D*)H1D_jetPhi[iCentralityBin]->Rebin(1.,"jetPhi_rebinned_"+Datasets[iDataset]+DatasetsNames[iDataset]+Form("%.1f", jetRadius)+"_@cent["+Form("%.1d", ibinCent_low)+","+Form("%.1d", ibinCent_high)+"]");
 
     H1D_jetPhi_rebinned_entriesnorm[iCentralityBin] = (TH1D*)H1D_jetPhi_rebinned[iCentralityBin]->Clone("jetPhi_rebinned_"+Datasets[iDataset]+DatasetsNames[iDataset]+Form("%.1f", jetRadius)+"_@cent["+Form("%.1d", ibinCent_low)+","+Form("%.1d", ibinCent_high)+"]_entriesNorm");
-    NormaliseYieldToIntegral(H1D_jetPhi_rebinned_entriesnorm[iCentralityBin]);
+    NormaliseYieldToNEntries(H1D_jetPhi_rebinned_entriesnorm[iCentralityBin]);
 
     // NormaliseYieldToNEntries(H1D_jetPhi_rebinned[iRadius]);
     NormaliseYieldToNEvents(H1D_jetPhi_rebinned[iCentralityBin], GetNEventsSelectedCentrality_JetFramework(file_O2Analysis_list[iDataset], analysisWorkflow[iDataset], arrayCentralityBinning[iCentralityBin], arrayCentralityBinning[iCentralityBin+1]));
@@ -1873,7 +1924,7 @@ void Draw_BkgFluctuations_CentralityProjection(int iDataset, std::array<std::arr
     H1D_fluctuations_rebinned[iCentralityBin] = (TH1D*)H1D_fluctuations[iCentralityBin]->Rebin(1.,"bkgFluctuationCentrality_rebinned_"+Datasets[iDataset]+DatasetsNames[iDataset]+"_@cent["+Form("%.1d", ibinCent_low)+","+Form("%.1d", ibinCent_high)+"]");
 
     if (options.find("normEntries") != std::string::npos) {
-      NormaliseYieldToIntegral(H1D_fluctuations_rebinned[iCentralityBin]);
+      NormaliseYieldToNEntries(H1D_fluctuations_rebinned[iCentralityBin]);
       yAxisLabel = texEntriesNorm_BkgFluctuationYield;
     }
     if (options.find("normEvents") != std::string::npos) {
@@ -1938,7 +1989,7 @@ void Draw_Rho_CentralityProjection(int iDataset, std::string options) {
     H1D_rho_rebinned[iCentralityBin] = (TH1D*)H1D_rho[iCentralityBin]->Rebin(1.,"bkgRhoCentrality_rebinned_"+Datasets[iDataset]+DatasetsNames[iDataset]+"_@cent["+Form("%.1d", ibinCent_low)+","+Form("%.1d", ibinCent_high)+"]");
 
     if (options.find("normEntries") != std::string::npos) {
-      NormaliseYieldToIntegral(H1D_rho_rebinned[iCentralityBin]);
+      NormaliseYieldToNEntries(H1D_rho_rebinned[iCentralityBin]);
       yAxisLabel = texEntriesNormRho;
     }
     if (options.find("normEvents") != std::string::npos) {
@@ -1996,7 +2047,7 @@ void Draw_Rho_CentralityProjection_DatasetComp(float* centRange, std::string opt
     H1D_rho_rebinned[iDataset] = (TH1D*)H1D_rho[iDataset]->Rebin(1.,"bkgRhoCentrality_rebinned_"+Datasets[iDataset]+DatasetsNames[iDataset]+"_@cent["+Form("%.1d", ibinCent_low)+","+Form("%.1d", ibinCent_high)+"]");
 
     if (options.find("normEntries") != std::string::npos) {
-      NormaliseYieldToIntegral(H1D_rho_rebinned[iDataset]);
+      NormaliseYieldToNEntries(H1D_rho_rebinned[iDataset]);
       yAxisLabel = texEntriesNormRho;
     }
     if (options.find("normEvents") != std::string::npos) {
@@ -2107,7 +2158,7 @@ void Draw_Eta_PtCutComparison(float jetRadius, int iDataset, float* PtCuts, int 
     H1D_jetEta_rebinned[iBinPt] = (TH1D*)H1D_jetEta[iBinPt]->Rebin(2.,"jetEta_rebinned_"+DatasetsNames[iDataset]+Form("%.1f", jetRadius)+Form("%.1f", PtCutLow)+"<pt");
 
     if (options.find("normEntries") != std::string::npos) {
-      NormaliseYieldToIntegral(H1D_jetEta_rebinned[iBinPt]);
+      NormaliseYieldToNEntries(H1D_jetEta_rebinned[iBinPt]);
       yAxisLabel = texJetEtaYield_EntriesNorm;
     }
     if (options.find("normEvents") != std::string::npos) {
@@ -2160,7 +2211,7 @@ void Draw_Phi_PtCutComparison(float jetRadius, int iDataset, float* PtCuts, int 
     H1D_jetPhi_rebinned[iBinPt] = (TH1D*)H1D_jetPhi[iBinPt]->Rebin(2.,"jetPhi_rebinned_"+DatasetsNames[iDataset]+Form("%.1f", jetRadius)+Form("%.1f", PtCutLow)+"<pt");
 
     if (options.find("normEntries") != std::string::npos) {
-      NormaliseYieldToIntegral(H1D_jetPhi_rebinned[iBinPt]);
+      NormaliseYieldToNEntries(H1D_jetPhi_rebinned[iBinPt]);
       yAxisLabel = texJetPhiYield_EntriesNorm;
     }
     if (options.find("normEvents") != std::string::npos) {
@@ -2208,9 +2259,9 @@ void Draw_BkgFluctuations_CentralityProjection_withFit_CentralityComp(int iDatas
   
   ////////////////////////////////// Fit initialisation //////////////////////////////////
   //Fit tools initialisation
-  std::vector<TF1*> gaussInit(nCentralityBins);
-  std::vector<TF1*> gaussFinal(nCentralityBins);
-  std::vector<TF1*> gaussDrawn(nCentralityBins); // drawn over the full range
+  TF1 *gaussInit[nCentralityBins];
+  TF1 *gaussFinal[nCentralityBins];
+  TF1 *gaussDrawn[nCentralityBins]; // drawn over the full range
   // TF1 *GaussPlusPolynom[nCentralityBins];
   // TF1 *bkgparab[nCentralityBins];
   TFitResultPtr fFitResult[nCentralityBins];
@@ -2229,7 +2280,7 @@ void Draw_BkgFluctuations_CentralityProjection_withFit_CentralityComp(int iDatas
     H1D_fluctuations_rebinned[iCentralityBin] = (TH1D*)H1D_fluctuations[iCentralityBin]->Rebin(1.,"bkgFluctuationCentrality_rebinned_"+Datasets[iDataset]+DatasetsNames[iDataset]+"_@cent["+Form("%.1d", ibinCent_low)+","+Form("%.1d", ibinCent_high)+"]");
 
     // if (options.find("normEntries") != std::string::npos) {
-    NormaliseYieldToIntegral(H1D_fluctuations_rebinned[iCentralityBin]);
+    NormaliseYieldToNEntries(H1D_fluctuations_rebinned[iCentralityBin]);
     yAxisLabel = texEntriesNorm_BkgFluctuationYield;
     // }
     // if (options.find("normEvents") != std::string::npos) {
@@ -2351,9 +2402,9 @@ void Draw_BkgFluctuations_CentralityProjection_withFit_DatasetComp(float* centRa
   
   ////////////////////////////////// Fit initialisation //////////////////////////////////
   //Fit tools initialisation
-  std::vector<TF1*> gaussInit(nDatasets);
-  std::vector<TF1*> gaussFinal(nDatasets);
-  std::vector<TF1*> gaussDrawn(nDatasets); // drawn over the full range
+  TF1 *gaussInit[nDatasets];
+  TF1 *gaussFinal[nDatasets];
+  TF1 *gaussDrawn[nDatasets]; // drawn over the full range
   // TF1 *GaussPlusPolynom[nDatasets];
   // TF1 *bkgparab[nDatasets];
   TFitResultPtr fFitResult[nDatasets];
@@ -2385,7 +2436,7 @@ void Draw_BkgFluctuations_CentralityProjection_withFit_DatasetComp(float* centRa
     H1D_fluctuations_rebinned[iDataset] = (TH1D*)H1D_fluctuations[iDataset]->Rebin(1.,"bkgFluctuationCentrality_rebinned_"+Datasets[iDataset]+DatasetsNames[iDataset]+methodRandomConeHistNames[iMethodRandomCone]+"_@cent["+Form("%.1d", ibinCent_low)+","+Form("%.1d", ibinCent_high)+"]");
 
     // if (options.find("normEntries") != std::string::npos) {
-    NormaliseYieldToIntegral(H1D_fluctuations_rebinned[iDataset]);
+    NormaliseYieldToNEntries(H1D_fluctuations_rebinned[iDataset]);
     yAxisLabel = texEntriesNorm_BkgFluctuationYield;
     // }
     // if (options.find("normEvents") != std::string::npos) {
@@ -2520,9 +2571,9 @@ void Draw_Rho_withFit_NTracksProjection(int iDataset) { /// should be bkgfluct v
 
   ////////////////////////////////// Fit initialisation //////////////////////////////////
   //Fit tools initialisation
-  std::vector<TF1*> gaussInit(nTracksBins);
-  std::vector<TF1*> gaussFinal(nTracksBins);
-  std::vector<TF1*> gaussDrawn(nTracksBins); // drawn over the full range
+  TF1 *gaussInit[nTracksBins];
+  TF1 *gaussFinal[nTracksBins];
+  TF1 *gaussDrawn[nTracksBins]; // drawn over the full range
   // TF1 *GaussPlusPolynom[nTracksBins];
   // TF1 *bkgparab[nTracksBins];
   TFitResultPtr fFitResult[nTracksBins];
@@ -2541,7 +2592,7 @@ void Draw_Rho_withFit_NTracksProjection(int iDataset) { /// should be bkgfluct v
     H1D_fluctuations_rebinned[iTracksBin] = (TH1D*)H1D_fluctuations[iTracksBin]->Rebin(1.,"bkgFluctuationCentrality_rebinned_"+Datasets[iDataset]+DatasetsNames[iDataset]+"_@cent["+Form("%.1d", ibinCent_low)+","+Form("%.1d", ibinCent_high)+"]");
 
     // if (options.find("normEntries") != std::string::npos) {
-    NormaliseYieldToIntegral(H1D_fluctuations_rebinned[iTracksBin]);
+    NormaliseYieldToNEntries(H1D_fluctuations_rebinned[iTracksBin]);
     yAxisLabel = texEntriesNorm_BkgFluctuationYield;
     // }
     // if (options.find("normEvents") != std::string::npos) {
@@ -3046,7 +3097,7 @@ void Draw_Pt_PbPbToPPComparison_HARDCODED(float jetRadius, float* etaRange, std:
     // cout << "test0.35" << endl;
 
     if (options.find("normEntries") != std::string::npos) {
-      NormaliseYieldToIntegral(H1D_jetPt_rebinned[iDataset]);
+      NormaliseYieldToNEntries(H1D_jetPt_rebinned[iDataset]);
       yAxisLabel = texJetPtYield_EntriesNorm;
     }
     double Nevents;
@@ -3103,9 +3154,9 @@ void Draw_BkgFluctuations_CentralityProjection_withFit_MethodComp(float* centRan
   
   ////////////////////////////////// Fit initialisation //////////////////////////////////
   //Fit tools initialisation
-  std::vector<TF1*> gaussInit(nMethodRC);
-  std::vector<TF1*> gaussFinal(nMethodRC);
-  std::vector<TF1*> gaussDrawn(nMethodRC); // drawn over the full range
+  TF1 *gaussInit[nMethodRC];
+  TF1 *gaussFinal[nMethodRC];
+  TF1 *gaussDrawn[nMethodRC]; // drawn over the full range
   // TF1 *GaussPlusPolynom[nMethodRC];
   // TF1 *bkgparab[nMethodRC];
   TFitResultPtr fFitResult[nMethodRC];
@@ -3137,7 +3188,7 @@ void Draw_BkgFluctuations_CentralityProjection_withFit_MethodComp(float* centRan
     H1D_fluctuations_rebinned[iMethodRC] = (TH1D*)H1D_fluctuations[iMethodRC]->Rebin(1.,"bkgFluctuationCentrality_rebinned_"+Datasets[iDataset]+DatasetsNames[iDataset]+methodRandomConeHistNames[iMethodRC]+"_@cent["+Form("%.0f", centRange[0])+","+Form("%.0f", centRange[1])+"]");
 
     // if (options.find("normEntries") != std::string::npos) {
-    NormaliseYieldToIntegral(H1D_fluctuations_rebinned[iMethodRC]);
+    NormaliseYieldToNEntries(H1D_fluctuations_rebinned[iMethodRC]);
     yAxisLabel = texEntriesNorm_BkgFluctuationYield;
     // }
     // if (options.find("normEvents") != std::string::npos) {
@@ -3672,9 +3723,9 @@ void Draw_PtPeakPosition_vs_leadTrackCut(float* etaRange, float jetRadiusForJetF
 
   ////////////////////////////////// Fit initialisation //////////////////////////////////
   //Fit tools initialisation
-  std::vector<TF1*> gaussInit(nDatasets);
-  std::vector<TF1*> gaussFinal(nDatasets);
-  std::vector<TF1*> gaussDrawn(nDatasets); // drawn over the full range
+  TF1 *gaussInit[nDatasets];
+  TF1 *gaussFinal[nDatasets];
+  TF1 *gaussDrawn[nDatasets]; // drawn over the full range
   // TF1 *GaussPlusPolynom[nDatasets];
   // TF1 *bkgparab[nDatasets];
   TFitResultPtr fFitResult[nDatasets];
@@ -3906,7 +3957,7 @@ void Draw_PtLeadCutStudy_PtOfRatio1(float* etaRange, std::string options, float 
     H1D_jetPt_rebinned[iDataset] = (TH1D*)H1D_jetPt[iDataset]->Rebin(1.,"jetPt_rebinned_2"+Datasets[iDataset]+DatasetsNames[iDataset]+"Radius"+Form("%.1f",jetRadius)+Form("%.1f", EtaCutLow)+"<eta<"+Form("%.1f", EtaCutHigh));
 
     if (options.find("normEntries") != std::string::npos) {
-      NormaliseYieldToIntegral(H1D_jetPt_rebinned[iDataset]);
+      NormaliseYieldToNEntries(H1D_jetPt_rebinned[iDataset]);
       yAxisLabel = texJetPtYield_EntriesNorm;
     }
     double Nevents;
@@ -4149,7 +4200,7 @@ void Draw_Pt_DatasetComparison_withRun2RitsuyaHardcoded(float* etaRange, std::st
 
     
     if (options.find("normEntries") != std::string::npos) {
-      NormaliseYieldToIntegral(H1D_jetPt_rebinned[iDataset]);
+      NormaliseYieldToNEntries(H1D_jetPt_rebinned[iDataset]);
       yAxisLabel = texJetPtYield_EntriesNorm;
     }
     double Nevents;

--- a/Jets/JetQC.C
+++ b/Jets/JetQC.C
@@ -154,12 +154,12 @@ void JetQC() {
   // const int nPtMinCuts = 7;
   // float jetPtMinCut;
   // float jetPtMinCutArray[nPtMinCuts] = {-999, 0, 5, 10, 15, 20, 40.};
-  const int nPtBins = 5;
-  float jetPtMinCut, jetPtMaxCut;
-  float jetPtMinCutArray[nPtBins+1] = {0.15, 10, 20, 40, 60, 200};
-  // const int nPtBins = 1;
+  // const int nPtBins = 5;
   // float jetPtMinCut, jetPtMaxCut;
-  // float jetPtMinCutArray[nPtBins+1] = {0.15, 200};
+  // float jetPtMinCutArray[nPtBins+1] = {0.15, 10, 20, 40, 60, 200};
+  const int nPtBins = 1;
+  float jetPtMinCut, jetPtMaxCut;
+  float jetPtMinCutArray[nPtBins+1] = {0.15, 200};
 
 
   // only for leading pT analysis, those two are a bit hardcoded
@@ -479,7 +479,7 @@ void Draw_Eta_RadiusComparison(int iDataset, float* PtRange) {
     H1D_jetEta[iRadius] = (TH1D*)H3D_jetRjetPtjetEta->ProjectionZ("jetEta_"+RadiusLegend[iRadius]+Form("%.1f", PtCutLow)+"<pt<"+Form("%.1f", PtCutHigh), ibinJetRadius, ibinJetRadius, ibinPt_low, ibinPt_high, "e");
     H1D_jetEta_rebinned[iRadius] = (TH1D*)H1D_jetEta[iRadius]->Rebin(1.,"jetEta_rebinned_"+RadiusLegend[iRadius]+Form("%.1f", PtCutLow)+"<pt<"+Form("%.1f", PtCutHigh));
 
-    NormaliseYieldToNEntries(H1D_jetEta_rebinned[iRadius]);
+    NormaliseYieldToIntegral(H1D_jetEta_rebinned[iRadius]);    
     // NormaliseYieldToNEvents(H1D_jetEta_rebinned[iRadius], GetNEventsSelected_JetFramework(file_O2Analysis_list[iDataset], analysisWorkflow[iDataset]));
   }
 
@@ -800,13 +800,13 @@ void Draw_Pt_DatasetComparison(float* etaRange, std::string options, float jetRa
     // H1D_jetPt_rebinned[iDataset] = (TH1D*)H1D_jetPt[iDataset]->Rebin(5.,"jetPt_rebinned_"+Datasets[iDataset]+DatasetsNames[iDataset]+"Radius"+Form("%.1f",jetRadius)+Form("%.1f", EtaCutLow)+"<eta<"+Form("%.1f", EtaCutHigh));
 
 
-    int nBinPtJets = 16;
-    double ptBinsJets[17] = {-10., -5., 0., 5., 10., 15., 20., 25., 30., 35., 40., 50., 60., 80., 100., 140., 200.};
-    H1D_jetPt_rebinned[iDataset] = (TH1D*)H1D_jetPt[iDataset]->Rebin(nBinPtJets,"jetPt_rebinned_"+Datasets[iDataset]+DatasetsNames[iDataset]+"Radius"+Form("%.1f",jetRadius)+Form("%.1f", EtaCutLow)+"<eta<"+Form("%.1f", EtaCutHigh), ptBinsJets);
+    // int nBinPtJets = 16;
+    // double ptBinsJets[17] = {-10., -5., 0., 5., 10., 15., 20., 25., 30., 35., 40., 50., 60., 80., 100., 140., 200.};
+    H1D_jetPt_rebinned[iDataset] = (TH1D*)H1D_jetPt[iDataset]->Rebin(1. ,"jetPt_rebinned_"+Datasets[iDataset]+DatasetsNames[iDataset]+"Radius"+Form("%.1f",jetRadius)+Form("%.1f", EtaCutLow)+"<eta<"+Form("%.1f", EtaCutHigh));
 
 
     if (options.find("normEntries") != std::string::npos) {
-      NormaliseYieldToNEntries(H1D_jetPt_rebinned[iDataset]);
+      NormaliseYieldToIntegral(H1D_jetPt_rebinned[iDataset]);
       yAxisLabel = texJetPtYield_EntriesNorm;
     }
     double Nevents;
@@ -849,7 +849,7 @@ void Draw_Pt_DatasetComparison(float* etaRange, std::string options, float jetRa
   // TString textContext(contextDatasetCompAndRadiusAndVarRange(jetRadius, etaRange, "eta"));
   TString textContext(contextCustomThreeFields(*texDatasetsComparisonCommonDenominator, "", "#splitline{"+contextJetRadius(jetRadius)+"}{"+contextEtaRange(etaRange)+"}", ""));
 
-  std::array<std::array<float, 2>, 2> drawnWindow = {{{-25, 200},{-999, -999}}};
+  std::array<std::array<float, 2>, 2> drawnWindow = {{{-25, 200},{10E-9, 40}}};
   std::array<std::array<float, 2>, 2> drawnWindowZoom = {{{-10, 200},{0.6, 1.6}}};
   std::array<std::array<float, 2>, 2> drawnWindowZoomTwoByTwo = {{{-25, 200},{0.5, 2}}};
   std::array<std::array<float, 2>, 2> legendPlacement = {{{0.65, 0.6}, {0.85, 0.85}}}; // {{{x1, y1}, {x2, y2}}}
@@ -919,19 +919,16 @@ void Draw_Eta_DatasetComparison(float jetRadius, float* PtRange, std::string opt
       cout << "Requested workflow is incorrect: it should be jet-finder-charged-qa or jet-spectra-charged" << endl;
     }
 
-
-    H1D_jetEta_rebinned[iDataset] = (TH1D*)H1D_jetEta[iDataset]->Rebin(5.,"jetEta_rebinned_"+Datasets[iDataset]+DatasetsNames[iDataset]+"Radius"+Form("%.1f",jetRadius)+Form("%.1f", PtCutLow)+"<pt<"+Form("%.1f", PtCutHigh));
-    cout << "getentries H3D = "<< H3D_jetRjetPtjetEta[iDataset]->GetEntries() << endl;
-    cout << "getentries H1D = "<< H1D_jetEta_rebinned[iDataset]->GetEntries() << endl;
-
     if (PtRange[0] < 40) {
       H1D_jetEta_rebinned[iDataset] = (TH1D*)H1D_jetEta[iDataset]->Rebin(5.,"jetEta_rebinned_"+Datasets[iDataset]+DatasetsNames[iDataset]+"Radius"+Form("%.1f",jetRadius)+Form("%.1f", PtCutLow)+"<pt<"+Form("%.1f", PtCutHigh));
     } else {
       H1D_jetEta_rebinned[iDataset] = (TH1D*)H1D_jetEta[iDataset]->Rebin(20.,"jetEta_rebinned_"+Datasets[iDataset]+DatasetsNames[iDataset]+"Radius"+Form("%.1f",jetRadius)+Form("%.1f", PtCutLow)+"<pt<"+Form("%.1f", PtCutHigh));
     }
+    cout << "getentries H3D = "<< H3D_jetRjetPtjetEta[iDataset]->GetEntries() << endl;
+    cout << "getentries H1D = "<< H1D_jetEta_rebinned[iDataset]->GetEntries() << endl;
 
     if (options.find("normEntries") != std::string::npos) {
-      NormaliseYieldToNEntries(H1D_jetEta_rebinned[iDataset]);
+      NormaliseYieldToIntegral(H1D_jetEta_rebinned[iDataset]);
       yAxisLabel = texJetEtaYield_EntriesNorm;
       pdfNameNorm = "normEntries";
     }
@@ -1044,7 +1041,7 @@ void Draw_Phi_DatasetComparison(float jetRadius, float* PtRange, std::string opt
     H1D_jetPhi_rebinned[iDataset] = (TH1D*)H1D_jetPhi[iDataset]->Rebin(5.,"jetPhi_rebinned_"+Datasets[iDataset]+DatasetsNames[iDataset]+"Radius"+Form("%.1f",jetRadius)+Form("%.1f", PtCutLow)+"<pt<"+Form("%.1f", PtCutHigh));
 
     if (options.find("normEntries") != std::string::npos) {
-      NormaliseYieldToNEntries(H1D_jetPhi_rebinned[iDataset]);
+      NormaliseYieldToIntegral(H1D_jetPhi_rebinned[iDataset]);
       yAxisLabel = texJetPhiYield_EntriesNorm;
     }
     double Nevents;
@@ -1821,7 +1818,7 @@ void Draw_Eta_CentralityComparison(float jetRadius, int iDataset) { //for now on
     H1D_jetEta_rebinned[iCentralityBin] = (TH1D*)H1D_jetEta[iCentralityBin]->Rebin(1.,"jetEta_rebinned_"+Datasets[iDataset]+DatasetsNames[iDataset]+Form("%.1f", jetRadius)+"_@cent["+Form("%.1d", ibinCent_low)+","+Form("%.1d", ibinCent_high)+"]");
 
     H1D_jetEta_rebinned_entriesnorm[iCentralityBin] = (TH1D*)H1D_jetEta_rebinned[iCentralityBin]->Clone("jetEta_rebinned_"+Datasets[iDataset]+DatasetsNames[iDataset]+Form("%.1f", jetRadius)+"_@cent["+Form("%.1d", ibinCent_low)+","+Form("%.1d", ibinCent_high)+"]_entriesNorm");
-    NormaliseYieldToNEntries(H1D_jetEta_rebinned_entriesnorm[iCentralityBin]);
+    NormaliseYieldToIntegral(H1D_jetEta_rebinned_entriesnorm[iCentralityBin]);
 
     NormaliseYieldToNEvents(H1D_jetEta_rebinned[iCentralityBin], GetNEventsSelectedCentrality_JetFramework(file_O2Analysis_list[iDataset], analysisWorkflow[iDataset], arrayCentralityBinning[iCentralityBin], arrayCentralityBinning[iCentralityBin+1]));
 
@@ -1869,7 +1866,7 @@ void Draw_Phi_CentralityComparison(float jetRadius, int iDataset) { //for now on
     H1D_jetPhi_rebinned[iCentralityBin] = (TH1D*)H1D_jetPhi[iCentralityBin]->Rebin(1.,"jetPhi_rebinned_"+Datasets[iDataset]+DatasetsNames[iDataset]+Form("%.1f", jetRadius)+"_@cent["+Form("%.1d", ibinCent_low)+","+Form("%.1d", ibinCent_high)+"]");
 
     H1D_jetPhi_rebinned_entriesnorm[iCentralityBin] = (TH1D*)H1D_jetPhi_rebinned[iCentralityBin]->Clone("jetPhi_rebinned_"+Datasets[iDataset]+DatasetsNames[iDataset]+Form("%.1f", jetRadius)+"_@cent["+Form("%.1d", ibinCent_low)+","+Form("%.1d", ibinCent_high)+"]_entriesNorm");
-    NormaliseYieldToNEntries(H1D_jetPhi_rebinned_entriesnorm[iCentralityBin]);
+    NormaliseYieldToIntegral(H1D_jetPhi_rebinned_entriesnorm[iCentralityBin]);
 
     // NormaliseYieldToNEntries(H1D_jetPhi_rebinned[iRadius]);
     NormaliseYieldToNEvents(H1D_jetPhi_rebinned[iCentralityBin], GetNEventsSelectedCentrality_JetFramework(file_O2Analysis_list[iDataset], analysisWorkflow[iDataset], arrayCentralityBinning[iCentralityBin], arrayCentralityBinning[iCentralityBin+1]));
@@ -1924,7 +1921,7 @@ void Draw_BkgFluctuations_CentralityProjection(int iDataset, std::array<std::arr
     H1D_fluctuations_rebinned[iCentralityBin] = (TH1D*)H1D_fluctuations[iCentralityBin]->Rebin(1.,"bkgFluctuationCentrality_rebinned_"+Datasets[iDataset]+DatasetsNames[iDataset]+"_@cent["+Form("%.1d", ibinCent_low)+","+Form("%.1d", ibinCent_high)+"]");
 
     if (options.find("normEntries") != std::string::npos) {
-      NormaliseYieldToNEntries(H1D_fluctuations_rebinned[iCentralityBin]);
+      NormaliseYieldToIntegral(H1D_fluctuations_rebinned[iCentralityBin]);
       yAxisLabel = texEntriesNorm_BkgFluctuationYield;
     }
     if (options.find("normEvents") != std::string::npos) {
@@ -1989,7 +1986,7 @@ void Draw_Rho_CentralityProjection(int iDataset, std::string options) {
     H1D_rho_rebinned[iCentralityBin] = (TH1D*)H1D_rho[iCentralityBin]->Rebin(1.,"bkgRhoCentrality_rebinned_"+Datasets[iDataset]+DatasetsNames[iDataset]+"_@cent["+Form("%.1d", ibinCent_low)+","+Form("%.1d", ibinCent_high)+"]");
 
     if (options.find("normEntries") != std::string::npos) {
-      NormaliseYieldToNEntries(H1D_rho_rebinned[iCentralityBin]);
+      NormaliseYieldToIntegral(H1D_rho_rebinned[iCentralityBin]);
       yAxisLabel = texEntriesNormRho;
     }
     if (options.find("normEvents") != std::string::npos) {
@@ -2047,7 +2044,7 @@ void Draw_Rho_CentralityProjection_DatasetComp(float* centRange, std::string opt
     H1D_rho_rebinned[iDataset] = (TH1D*)H1D_rho[iDataset]->Rebin(1.,"bkgRhoCentrality_rebinned_"+Datasets[iDataset]+DatasetsNames[iDataset]+"_@cent["+Form("%.1d", ibinCent_low)+","+Form("%.1d", ibinCent_high)+"]");
 
     if (options.find("normEntries") != std::string::npos) {
-      NormaliseYieldToNEntries(H1D_rho_rebinned[iDataset]);
+      NormaliseYieldToIntegral(H1D_rho_rebinned[iDataset]);
       yAxisLabel = texEntriesNormRho;
     }
     if (options.find("normEvents") != std::string::npos) {
@@ -2158,7 +2155,7 @@ void Draw_Eta_PtCutComparison(float jetRadius, int iDataset, float* PtCuts, int 
     H1D_jetEta_rebinned[iBinPt] = (TH1D*)H1D_jetEta[iBinPt]->Rebin(2.,"jetEta_rebinned_"+DatasetsNames[iDataset]+Form("%.1f", jetRadius)+Form("%.1f", PtCutLow)+"<pt");
 
     if (options.find("normEntries") != std::string::npos) {
-      NormaliseYieldToNEntries(H1D_jetEta_rebinned[iBinPt]);
+      NormaliseYieldToIntegral(H1D_jetEta_rebinned[iBinPt]);
       yAxisLabel = texJetEtaYield_EntriesNorm;
     }
     if (options.find("normEvents") != std::string::npos) {
@@ -2211,7 +2208,7 @@ void Draw_Phi_PtCutComparison(float jetRadius, int iDataset, float* PtCuts, int 
     H1D_jetPhi_rebinned[iBinPt] = (TH1D*)H1D_jetPhi[iBinPt]->Rebin(2.,"jetPhi_rebinned_"+DatasetsNames[iDataset]+Form("%.1f", jetRadius)+Form("%.1f", PtCutLow)+"<pt");
 
     if (options.find("normEntries") != std::string::npos) {
-      NormaliseYieldToNEntries(H1D_jetPhi_rebinned[iBinPt]);
+      NormaliseYieldToIntegral(H1D_jetPhi_rebinned[iBinPt]);
       yAxisLabel = texJetPhiYield_EntriesNorm;
     }
     if (options.find("normEvents") != std::string::npos) {
@@ -2259,9 +2256,9 @@ void Draw_BkgFluctuations_CentralityProjection_withFit_CentralityComp(int iDatas
   
   ////////////////////////////////// Fit initialisation //////////////////////////////////
   //Fit tools initialisation
-  TF1 *gaussInit[nCentralityBins];
-  TF1 *gaussFinal[nCentralityBins];
-  TF1 *gaussDrawn[nCentralityBins]; // drawn over the full range
+  std::vector<TF1*> gaussInit(nCentralityBins);
+  std::vector<TF1*> gaussFinal(nCentralityBins);
+  std::vector<TF1*> gaussDrawn(nCentralityBins); // drawn over the full range
   // TF1 *GaussPlusPolynom[nCentralityBins];
   // TF1 *bkgparab[nCentralityBins];
   TFitResultPtr fFitResult[nCentralityBins];
@@ -2280,7 +2277,7 @@ void Draw_BkgFluctuations_CentralityProjection_withFit_CentralityComp(int iDatas
     H1D_fluctuations_rebinned[iCentralityBin] = (TH1D*)H1D_fluctuations[iCentralityBin]->Rebin(1.,"bkgFluctuationCentrality_rebinned_"+Datasets[iDataset]+DatasetsNames[iDataset]+"_@cent["+Form("%.1d", ibinCent_low)+","+Form("%.1d", ibinCent_high)+"]");
 
     // if (options.find("normEntries") != std::string::npos) {
-    NormaliseYieldToNEntries(H1D_fluctuations_rebinned[iCentralityBin]);
+    NormaliseYieldToIntegral(H1D_fluctuations_rebinned[iCentralityBin]);
     yAxisLabel = texEntriesNorm_BkgFluctuationYield;
     // }
     // if (options.find("normEvents") != std::string::npos) {
@@ -2402,9 +2399,9 @@ void Draw_BkgFluctuations_CentralityProjection_withFit_DatasetComp(float* centRa
   
   ////////////////////////////////// Fit initialisation //////////////////////////////////
   //Fit tools initialisation
-  TF1 *gaussInit[nDatasets];
-  TF1 *gaussFinal[nDatasets];
-  TF1 *gaussDrawn[nDatasets]; // drawn over the full range
+  std::vector<TF1*> gaussInit(nDatasets);
+  std::vector<TF1*> gaussFinal(nDatasets);
+  std::vector<TF1*> gaussDrawn(nDatasets); // drawn over the full range
   // TF1 *GaussPlusPolynom[nDatasets];
   // TF1 *bkgparab[nDatasets];
   TFitResultPtr fFitResult[nDatasets];
@@ -2436,7 +2433,7 @@ void Draw_BkgFluctuations_CentralityProjection_withFit_DatasetComp(float* centRa
     H1D_fluctuations_rebinned[iDataset] = (TH1D*)H1D_fluctuations[iDataset]->Rebin(1.,"bkgFluctuationCentrality_rebinned_"+Datasets[iDataset]+DatasetsNames[iDataset]+methodRandomConeHistNames[iMethodRandomCone]+"_@cent["+Form("%.1d", ibinCent_low)+","+Form("%.1d", ibinCent_high)+"]");
 
     // if (options.find("normEntries") != std::string::npos) {
-    NormaliseYieldToNEntries(H1D_fluctuations_rebinned[iDataset]);
+    NormaliseYieldToIntegral(H1D_fluctuations_rebinned[iDataset]);
     yAxisLabel = texEntriesNorm_BkgFluctuationYield;
     // }
     // if (options.find("normEvents") != std::string::npos) {
@@ -2571,9 +2568,9 @@ void Draw_Rho_withFit_NTracksProjection(int iDataset) { /// should be bkgfluct v
 
   ////////////////////////////////// Fit initialisation //////////////////////////////////
   //Fit tools initialisation
-  TF1 *gaussInit[nTracksBins];
-  TF1 *gaussFinal[nTracksBins];
-  TF1 *gaussDrawn[nTracksBins]; // drawn over the full range
+  std::vector<TF1*> gaussInit(nTracksBins);
+  std::vector<TF1*> gaussFinal(nTracksBins);
+  std::vector<TF1*> gaussDrawn(nTracksBins); // drawn over the full range
   // TF1 *GaussPlusPolynom[nTracksBins];
   // TF1 *bkgparab[nTracksBins];
   TFitResultPtr fFitResult[nTracksBins];
@@ -2592,7 +2589,7 @@ void Draw_Rho_withFit_NTracksProjection(int iDataset) { /// should be bkgfluct v
     H1D_fluctuations_rebinned[iTracksBin] = (TH1D*)H1D_fluctuations[iTracksBin]->Rebin(1.,"bkgFluctuationCentrality_rebinned_"+Datasets[iDataset]+DatasetsNames[iDataset]+"_@cent["+Form("%.1d", ibinCent_low)+","+Form("%.1d", ibinCent_high)+"]");
 
     // if (options.find("normEntries") != std::string::npos) {
-    NormaliseYieldToNEntries(H1D_fluctuations_rebinned[iTracksBin]);
+    NormaliseYieldToIntegral(H1D_fluctuations_rebinned[iTracksBin]);
     yAxisLabel = texEntriesNorm_BkgFluctuationYield;
     // }
     // if (options.find("normEvents") != std::string::npos) {
@@ -3097,7 +3094,7 @@ void Draw_Pt_PbPbToPPComparison_HARDCODED(float jetRadius, float* etaRange, std:
     // cout << "test0.35" << endl;
 
     if (options.find("normEntries") != std::string::npos) {
-      NormaliseYieldToNEntries(H1D_jetPt_rebinned[iDataset]);
+      NormaliseYieldToIntegral(H1D_jetPt_rebinned[iDataset]);
       yAxisLabel = texJetPtYield_EntriesNorm;
     }
     double Nevents;
@@ -3154,9 +3151,9 @@ void Draw_BkgFluctuations_CentralityProjection_withFit_MethodComp(float* centRan
   
   ////////////////////////////////// Fit initialisation //////////////////////////////////
   //Fit tools initialisation
-  TF1 *gaussInit[nMethodRC];
-  TF1 *gaussFinal[nMethodRC];
-  TF1 *gaussDrawn[nMethodRC]; // drawn over the full range
+  std::vector<TF1*> gaussInit(nMethodRC);
+  std::vector<TF1*> gaussFinal(nMethodRC);
+  std::vector<TF1*> gaussDrawn(nMethodRC); // drawn over the full range
   // TF1 *GaussPlusPolynom[nMethodRC];
   // TF1 *bkgparab[nMethodRC];
   TFitResultPtr fFitResult[nMethodRC];
@@ -3188,7 +3185,7 @@ void Draw_BkgFluctuations_CentralityProjection_withFit_MethodComp(float* centRan
     H1D_fluctuations_rebinned[iMethodRC] = (TH1D*)H1D_fluctuations[iMethodRC]->Rebin(1.,"bkgFluctuationCentrality_rebinned_"+Datasets[iDataset]+DatasetsNames[iDataset]+methodRandomConeHistNames[iMethodRC]+"_@cent["+Form("%.0f", centRange[0])+","+Form("%.0f", centRange[1])+"]");
 
     // if (options.find("normEntries") != std::string::npos) {
-    NormaliseYieldToNEntries(H1D_fluctuations_rebinned[iMethodRC]);
+    NormaliseYieldToIntegral(H1D_fluctuations_rebinned[iMethodRC]);
     yAxisLabel = texEntriesNorm_BkgFluctuationYield;
     // }
     // if (options.find("normEvents") != std::string::npos) {
@@ -3723,9 +3720,9 @@ void Draw_PtPeakPosition_vs_leadTrackCut(float* etaRange, float jetRadiusForJetF
 
   ////////////////////////////////// Fit initialisation //////////////////////////////////
   //Fit tools initialisation
-  TF1 *gaussInit[nDatasets];
-  TF1 *gaussFinal[nDatasets];
-  TF1 *gaussDrawn[nDatasets]; // drawn over the full range
+  std::vector<TF1*> gaussInit(nDatasets);
+  std::vector<TF1*> gaussFinal(nDatasets);
+  std::vector<TF1*> gaussDrawn(nDatasets); // drawn over the full range
   // TF1 *GaussPlusPolynom[nDatasets];
   // TF1 *bkgparab[nDatasets];
   TFitResultPtr fFitResult[nDatasets];
@@ -3957,7 +3954,7 @@ void Draw_PtLeadCutStudy_PtOfRatio1(float* etaRange, std::string options, float 
     H1D_jetPt_rebinned[iDataset] = (TH1D*)H1D_jetPt[iDataset]->Rebin(1.,"jetPt_rebinned_2"+Datasets[iDataset]+DatasetsNames[iDataset]+"Radius"+Form("%.1f",jetRadius)+Form("%.1f", EtaCutLow)+"<eta<"+Form("%.1f", EtaCutHigh));
 
     if (options.find("normEntries") != std::string::npos) {
-      NormaliseYieldToNEntries(H1D_jetPt_rebinned[iDataset]);
+      NormaliseYieldToIntegral(H1D_jetPt_rebinned[iDataset]);
       yAxisLabel = texJetPtYield_EntriesNorm;
     }
     double Nevents;
@@ -4200,7 +4197,7 @@ void Draw_Pt_DatasetComparison_withRun2RitsuyaHardcoded(float* etaRange, std::st
 
     
     if (options.find("normEntries") != std::string::npos) {
-      NormaliseYieldToNEntries(H1D_jetPt_rebinned[iDataset]);
+      NormaliseYieldToIntegral(H1D_jetPt_rebinned[iDataset]);
       yAxisLabel = texJetPtYield_EntriesNorm;
     }
     double Nevents;

--- a/Jets/JetQC.C
+++ b/Jets/JetQC.C
@@ -183,11 +183,8 @@ void JetQC() {
 
     // Draw_Eta_DatasetComparison(jetRadiusForDataComp, ptRange, "normEvents");
     // Draw_Eta_DatasetComparison(jetRadiusForDataComp, ptRange, "normEntries");
-<<<<<<< HEAD
     // Draw_Phi_DatasetComparison(jetRadiusForDataComp, ptRange, "normEvents");
-=======
     Draw_Phi_DatasetComparison(jetRadiusForDataComp, ptRange, "normEvents");
->>>>>>> 8af6bc2 (adding ratio plots in JetQC and legends in Tracks)
 
     // Draw_Constituent_Pt_DatasetComparison(ptRange, jetRadiusForDataComp);
 

--- a/Tracks/TrackMcQC.C
+++ b/Tracks/TrackMcQC.C
@@ -116,9 +116,9 @@ void TrackMcQC() {
   // Draw_Efficiency_Pt_ratio_etaNeg_etaPos_DatasetComparison(etaRange, useSplit);
   // // Draw_Efficiency_Phi_DatasetComparison_finerPhi(ptRange1, etaRange); // only works with very specific datasets created locally
 
-  // Draw_Purity_Pt_DatasetComparison(etaRange, useSplit);
-  // Draw_Purity_Eta_DatasetComparison(etaRange, useSplit);
-  // Draw_Purity_Phi_DatasetComparison(etaRange, useSplit);
+  Draw_Purity_Pt_DatasetComparison(etaRange, useSplit);
+  Draw_Purity_Eta_DatasetComparison(etaRange, useSplit);
+  Draw_Purity_Phi_DatasetComparison(etaRange, useSplit);
   // Draw_Purity_Pt_ratio_etaNeg_etaPos_DatasetComparison(etaRange, useSplit);
 
   // int nPtRanges = 10;
@@ -172,7 +172,7 @@ void TrackMcQC() {
   // Draw_Pt_gen_DatasetComparison_H2CentVersion("primaries,secondaries, ratio");
   // Draw_Eta_gen_DatasetComparison_H2CentVersion("primaries,secondaries, ratio");
   // Draw_Phi_gen_DatasetComparison_H2CentVersion("primaries,secondaries, ratio");
-  Draw_PtResolution_Residuals("ptRes_vs_pt");
+  // Draw_PtResolution_Residuals("ptRes_vs_pt");
 }
 /////////////////////////////////////////////////////
 /////////////////// Misc utilities //////////////////
@@ -306,7 +306,6 @@ void Draw_Efficiency_Pt_DatasetComparison(float* etaRange, bool useSplit, bool u
 
   int nBinsPt;
   for(int iDataset = 0; iDataset < nDatasets; iDataset++){
-
     H3D_trackPtEtaPhi_mcparticles[iDataset] = (TH3D*)((TH3D*)file_O2Analysis_list[iDataset]->Get(analysisWorkflow[iDataset]+"/h3_particle_pt_particle_eta_particle_phi_mcpartofinterest"))->Clone("Draw_Efficiency_Pt_DatasetComparison_mcparticles"+Datasets[iDataset]+DatasetsNames[iDataset]);
     H3D_trackPtEtaPhi_mcparticles_ptHigh[iDataset] = (TH3D*)((TH3D*)file_O2Analysis_list[iDataset]->Get(analysisWorkflow[iDataset]+"/h3_particle_pt_high_particle_eta_particle_phi_mcpartofinterest"))->Clone("Draw_Efficiency_Pt_DatasetComparison_mcparticles_ptHigh"+Datasets[iDataset]+DatasetsNames[iDataset]);
     H3D_trackPtEtaPhi_assoctracks[iDataset] = (TH3D*)((TH3D*)file_O2Analysis_list[iDataset]->Get(analysisWorkflow[iDataset]+"/h3_particle_pt_particle_eta_particle_phi_associatedtrack_primary"))->Clone("Draw_Efficiency_Pt_DatasetComparison_associatedtrackSelColl"+Datasets[iDataset]+DatasetsNames[iDataset]);
@@ -329,7 +328,6 @@ void Draw_Efficiency_Pt_DatasetComparison(float* etaRange, bool useSplit, bool u
       H1D_trackPt_assoctracks_split[iDataset] = (TH1D*)H3D_trackPtEtaPhi_assoctracks_split[iDataset]->ProjectionX("trackPt_assoctracks_split"+Datasets[iDataset]+DatasetsNames[iDataset], ibinEta_low_track, ibinEta_high_track, 0, -1, "e");
       H1D_trackPt_assoctracks_split_ptHigh[iDataset] = (TH1D*)H3D_trackPtEtaPhi_assoctracks_split_ptHigh[iDataset]->ProjectionX("trackPt_assoctracks_split_ptHigh"+Datasets[iDataset]+DatasetsNames[iDataset], ibinEta_low_track, ibinEta_high_track, 0, -1, "e");
     }
-
     //tweaking the low-pt bins to make them larger close to 10GeV
     std::vector<double> xbinsVectorInitialLow = GetTH1Bins(H1D_trackPt_mcparticles[iDataset]);
     double* xbinsInitialLow = &xbinsVectorInitialLow[0];
@@ -398,7 +396,6 @@ void Draw_Efficiency_Pt_DatasetComparison(float* etaRange, bool useSplit, bool u
     H1D_trackPt_efficiency_ptHigh[iDataset] = (TH1D*)H1D_trackPt_mcparticles_ptHigh_rebinned[iDataset]->Clone("trackPt_efficiency_ptHigh"+Datasets[iDataset]+DatasetsNames[iDataset]);
     H1D_trackPt_efficiency_ptHigh[iDataset]->Reset("M");
     divideSuccess_ptHigh = H1D_trackPt_efficiency_ptHigh[iDataset]->Divide(H1D_trackPt_assoctracks_ptHigh_rebinned[iDataset], H1D_trackPt_mcparticles_ptHigh_rebinned[iDataset], 1., 1., "b"); // option b for binomial because efficiency: https://twiki.cern.ch/twiki/bin/view/ALICE/PWGLFPAGSTRANGENESSEfficiency
-
     // correcting for split tracks
     if (useSplit == true) {
       //getting the efficiency : for split corrected 
@@ -420,7 +417,6 @@ void Draw_Efficiency_Pt_DatasetComparison(float* etaRange, bool useSplit, bool u
       H1D_trackPt_efficiency_splitNotCorrected_ptHigh[iDataset]->Reset("M");
       divideSuccess_split__notCorrectedPtHigh = H1D_trackPt_efficiency_splitNotCorrected_ptHigh[iDataset]->Divide(H1D_trackPt_assoctracks_split_ptHigh_rebinned[iDataset], H1D_trackPt_mcparticles_ptHigh_rebinned[iDataset], 1., 1., "b");
     }
-
     // Merging high and low pt histograms:
     // x-axis
     std::vector<double> xbinsVectorLeft = GetTH1Bins(H1D_trackPt_efficiency[iDataset]);
@@ -481,7 +477,6 @@ void Draw_Efficiency_Pt_DatasetComparison(float* etaRange, bool useSplit, bool u
       divideSuccessRatio = H1D_trackPt_efficiency_ratios[iDataset]->Divide(H1D_trackPt_efficiency_concatenated[iDataset], H1D_trackPt_efficiency_concatenated[0], 1., 1., datasetsAreSubsetsofId0 ? "b" : "");
     }
   }
-
   TString* pdfNameEntriesNorm = new TString("track_Pt_efficiency"+dummyName[0]+"_@eta["+Form("%.1f", etaRange[0])+","+Form("%.1f", etaRange[1])+"]");
   TString* pdfNameEntriesNorm_zoom = new TString("track_Pt_efficiency"+dummyName[0]+"_@eta["+Form("%.1f", etaRange[0])+","+Form("%.1f", etaRange[1])+"]_zoom");
   TString* pdfNameEntriesNorm_splitCorrected = new TString("track_Pt_efficiency"+dummyName[0]+"_@eta["+Form("%.1f", etaRange[0])+","+Form("%.1f", etaRange[1])+"]_splitCorrected");
@@ -705,8 +700,6 @@ void Draw_Efficiency_Eta_DatasetComparison(float* ptRange, bool useSplit) {
 
   // TString textContext(contextDatasetComp(""));
   TString textContext(contextCustomTwoFields(*texDatasetsComparisonCommonDenominator, contextPtRange(ptRange), ""));
-  std::array<std::array<float, 2>, 2> drawnZoom = {{{(float)H1D_trackEta_efficiency[0]->GetXaxis()->GetXmin(), (float)H1D_trackEta_efficiency[0]->GetXaxis()->GetXmax()}, 
-                                                    {0.6, 1}}}; // {{xmin, xmax}, {ymin, ymax}}
 
   if (divideSuccess == true) {
     Draw_TH1_Histograms(H1D_trackEta_efficiency, DatasetsNames, nDatasets, textContext, pdfNameEntriesNorm, texEtaMC, texTrackEfficiency, texCollisionDataInfo, drawnWindowAuto, legendPlacementEta, contextPlacementAuto, "efficiency"+histDatasetComparisonStructure);
@@ -745,18 +738,14 @@ void Draw_Efficiency_Phi_DatasetComparison(float* ptRange, float* etaRange, bool
   TH3D* H3D_trackPtEtaPhi_mcparticles[nDatasets];
   TH3D* H3D_trackPtEtaPhi_assoctracks[nDatasets];
   TH3D* H3D_trackPtEtaPhi_assoctracks_split[nDatasets];
-  TH3D* H3D_trackPtEtaPhi_assoctracks_nonSplitSecondary[nDatasets];
 
   TH1D* H1D_trackPhi_mcparticles[nDatasets];
-
   TH1D* H1D_trackPhi_assoctracks[nDatasets];
   TH1D* H1D_trackPhi_assoctracks_split[nDatasets];
-  TH1D* H1D_trackPhi_assoctracks_nonSplitSecondary[nDatasets];
   
   TH1D* H1D_trackPhi_efficiency[nDatasets];
   // TH1D* H1D_trackPhi_efficiency_split[nDatasets];
   TH1D* H1D_trackPhi_efficiency_splitCorrected[nDatasets];
-  TH1D* H1D_trackPhi_efficiency_splitAndSecondaryCorrected[nDatasets];
 
   bool divideSuccess = false;
   bool divideSuccess_split = false;
@@ -842,6 +831,8 @@ void Draw_Efficiency_Phi_DatasetComparison(float* ptRange, float* etaRange, bool
         DatasetsNamesPairRatio[iDataset] = DatasetsNames[2*iDataset]+(TString)"/"+DatasetsNames[2*iDataset+1];
         H1D_trackPhi_efficiency_ratios[iDataset] = (TH1D*)H1D_trackPhi_efficiency[2*iDataset]->Clone("H1D_trackPhi_efficiency_ratio"+Datasets[iDataset]+DatasetsNames[iDataset]);
         H1D_trackPhi_efficiency_ratios[iDataset]->Reset("M");
+        cout << "Nbins X PHI 2i = "<< H1D_trackPhi_efficiency[2*iDataset]->GetNbinsX()<< endl;
+        cout << "Nbins X PHI 2i+1 = "<< H1D_trackPhi_efficiency[2*iDataset+1]->GetNbinsX()<< endl;
         divideSuccessRatio = H1D_trackPhi_efficiency_ratios[iDataset]->Divide(H1D_trackPhi_efficiency[2*iDataset], H1D_trackPhi_efficiency[2*iDataset+1]);
       }
     } else {
@@ -860,8 +851,6 @@ void Draw_Efficiency_Phi_DatasetComparison(float* ptRange, float* etaRange, bool
   // TString textContext(contextDatasetComp(""));
   TString textContext(contextCustomTwoFields(*texDatasetsComparisonCommonDenominator, "#splitline{"+contextPtRange(ptRange)+"}{"+contextEtaRange(etaRange)+"}", ""));
   std::array<std::array<float, 2>, 2> legendPlacementPhi = {{{0.65, 0.65}, {0.85, 0.85}}};
-  std::array<std::array<float, 2>, 2> drawnZoom = {{{(float)H1D_trackPhi_efficiency[0]->GetXaxis()->GetXmin(), (float)H1D_trackPhi_efficiency[0]->GetXaxis()->GetXmax()}, 
-                                                    {0.45, 1}}}; // {{xmin, xmax}, {ymin, ymax}}
 
   std::array<std::array<float, 2>, 2> drawnWindowLogEff_zoom = {{{-999, -999}, {0.5, 1}}};
   std::array<std::array<float, 2>, 2> drawnWindowLogEffRatio_zoom = {{{-999, -999}, {0.8, 1.2}}};
@@ -888,7 +877,6 @@ void Draw_Efficiency_Phi_DatasetComparison(float* ptRange, float* etaRange, bool
     if (histDatasetComparisonStructure.find("twoByTwoDatasetPairs") != std::string::npos) {
       Draw_TH1_Histograms(H1D_trackPhi_efficiency_ratios, DatasetsNamesPairRatio, nHistPairRatio, textContext, pdfName_ratio, texPhiMC, texRatio, texCollisionDataInfo, drawnWindowAuto, legendPlacementPhi, contextPlacementAuto, "zoomToOneLarge,ratioLine");
       Draw_TH1_Histograms(H1D_trackPhi_efficiency_ratios, DatasetsNamesPairRatio, nHistPairRatio, textContext, pdfName_ratio_zoom, texPhiMC, texRatio, texCollisionDataInfo, drawnWindowLogEffRatio_zoom, legendPlacementPhi, contextPlacementAuto, "zoomToOneLarge,ratioLine");
-      TString* pdfName_ratio_zoom = new TString("track_Phi_efficiency"+dummyName[0]+"_@pt["+Form("%.2f", ptRange[0])+","+Form("%.1f", ptRange[1])+"]_ratio_zoom");
     } else {
     Draw_TH1_Histograms(H1D_trackPhi_efficiency_ratios, DatasetsNames, nDatasets, textContext, pdfName_ratio, texPhiMC, texRatioDatasets, texCollisionDataInfo, drawnWindowAuto, legendPlacementPhi, contextPlacementAuto, "zoomToOneLarge,noMarkerFirst,ratioLine"+histDatasetComparisonStructure);
     Draw_TH1_Histograms(H1D_trackPhi_efficiency_ratios, DatasetsNames, nDatasets, textContext, pdfName_ratio_zoom, texPhiMC, texRatioDatasets, texCollisionDataInfo, drawnWindowLogEffRatio_zoom, legendPlacementPhi, contextPlacementAuto, "zoomToOneLarge,noMarkerFirst,ratioLine"+histDatasetComparisonStructure);
@@ -1543,7 +1531,7 @@ void Draw_Purity_Pt_DatasetComparison(float* etaRange, bool useSplit) {
   std::array<std::array<float, 2>, 2> legendPlacementPurity = {{{0.45, 0.2}, {0.8, 0.55}}}; // {{xmin, xmax}, {ymin, ymax}}
 
   if (divideSuccess == true && divideSuccess_High ==true ) {
-    Draw_TH1_Histograms(H1D_trackPt_purity_concatenated, DatasetsNames, nDatasets, textContext, pdfNameEntriesNorm, texPtRec, texTrackPurity, texCollisionDataInfo, drawnWindowPurity, legendPlacementPurity, contextPlacementPurity, "logx,efficiency,150MevLine");
+    Draw_TH1_Histograms(H1D_trackPt_purity_concatenated, DatasetsNames, nDatasets, textContext, pdfNameEntriesNorm, texPtRec, texTrackPurity, texCollisionDataInfo, drawnWindowPurity, legendPlacementPurity, contextPlacementPurity, "logx,efficiency,150MevLine"+histDatasetComparisonStructure);
   }
   else {
     cout << "Divide failed in Draw_Purity_Pt_DatasetComparison_legacy" << endl;
@@ -1568,6 +1556,7 @@ void Draw_Purity_Pt_DatasetComparison(float* etaRange, bool useSplit) {
   std::array<std::array<float, 2>, 2> drawnWindowLogZoom = {{{-999, -999} , {0.98, 1.18}}}; // {{xmin, xmax}, {ymin, ymax}}
   std::array<std::array<float, 2>, 2> legendPlacementPurityRatio = {{{0.2, 0.2}, {0.8, 0.4}}}; // {{xmin, xmax}, {ymin, ymax}}
   TString* pdfName_ratio = new TString("track_Pt_purity"+dummyName[0]+"_@eta["+Form("%.1f", etaRange[0])+","+Form("%.1f", etaRange[1])+"]_ratio");
+
   if (divideSuccessRatio == true) {
     if (histDatasetComparisonStructure.find("twoByTwoDatasetPairs") != std::string::npos) {
       Draw_TH1_Histograms(H1D_trackPt_purity_ratios, DatasetsNamesPairRatio, nHistPairRatio, textContext, pdfName_ratio, texPtX, texRatio, texCollisionDataInfo, drawnWindowLog, legendPlacementPurityRatio, contextPlacementPurityRatio, "logx,150MevLine,zoomToOneLarge,ratioLine");
@@ -1623,7 +1612,10 @@ void Draw_Purity_Eta_DatasetComparison(float* etaRange, bool useSplit) {
 
     H1D_primaryPurity_denominator[iDataset] = (TH1D*)H1D_trackEta_primary[iDataset]->Clone("trackEta_primaryPurity_denominator"+Datasets[iDataset]+DatasetsNames[iDataset]);
     H1D_primaryPurity_denominator[iDataset]->Add(H1D_trackEta_secondary[iDataset],1.);
-    divideSuccess = H1D_trackEta_primaryPurity[iDataset]->Divide(H1D_trackEta_primary[iDataset], H1D_primaryPurity_denominator[iDataset]);
+    cout << "  - " << DatasetsNames[iDataset] << ":" << endl;
+    cout << "     eta eff #### tracks count = " << H1D_trackEta_primary[iDataset]->GetEntries() << ", part count = " << H1D_primaryPurity_denominator[iDataset]->GetEntries() << endl;
+    divideSuccess = H1D_trackEta_primaryPurity[iDataset]->Divide(H1D_trackEta_primary[iDataset], H1D_primaryPurity_denominator[iDataset],1.,1.,"b");
+
 
     // naming the histogram and resetting it to have a chosen name
     if (useSplit == true) {
@@ -1636,10 +1628,33 @@ void Draw_Purity_Eta_DatasetComparison(float* etaRange, bool useSplit) {
       }
   }
 
+  TH1D* H1D_trackEta_purity_ratios[nDatasets];
+  TString DatasetsNamesPairRatio[nDatasets];
+  int nHistPairRatio = (int)nDatasets / 2;
+  bool divideSuccessRatio;
+  for(int iDataset = 0; iDataset < nDatasets; iDataset++){
+    if (histDatasetComparisonStructure.find("twoByTwoDatasetPairs") != std::string::npos) { //twoByTwoDatasetPairs assumes a Datasets array like so: {pair1_element1, pair1_element2, pair2_element1, pair2_element2..., pairN_element1, pairN_element2}
+      if (iDataset < nHistPairRatio) {
+          DatasetsNamesPairRatio[iDataset] = DatasetsNames[2*iDataset]+(TString)"/"+DatasetsNames[2*iDataset+1];
+          H1D_trackEta_purity_ratios[iDataset] = (TH1D*)H1D_trackEta_primaryPurity[2*iDataset]->Clone("H1D_trackEta_primaryPurity_ratio"+Datasets[iDataset]+DatasetsNames[iDataset]);
+          H1D_trackEta_purity_ratios[iDataset]->Reset("M");
+          cout << "Denominator integral (dataset "<< 2*iDataset+1 << ") = "<< H1D_trackEta_primaryPurity[2*iDataset+1]->Integral()<< endl;
+          cout << "Nbins X ETA 2i = "<< H1D_trackEta_primaryPurity[2*iDataset]->GetNbinsX()<< endl;
+          cout << "Nbins X ETA 2i+1 = "<< H1D_trackEta_primaryPurity[2*iDataset+1]->GetNbinsX()<< endl;
+          divideSuccessRatio = H1D_trackEta_purity_ratios[iDataset]->Divide(H1D_trackEta_primaryPurity[2*iDataset], H1D_trackEta_primaryPurity[2*iDataset+1]);
+      }
+    } else {
+        H1D_trackEta_purity_ratios[iDataset] = (TH1D*)H1D_trackEta_primaryPurity[iDataset]->Clone("H1D_trackEta_primaryPurity_ratio"+Datasets[iDataset]+DatasetsNames[iDataset]);
+        H1D_trackEta_purity_ratios[iDataset]->Reset("M");
+        divideSuccessRatio = H1D_trackEta_purity_ratios[iDataset]->Divide(H1D_trackEta_primaryPurity[iDataset], H1D_trackEta_primaryPurity[0]);
+    }
+  }
+
   TString* pdfNameEntriesNorm = new TString("track_Eta_primaryPurity"+dummyName[0]+"_@eta["+Form("%.1f", etaRange[0])+","+Form("%.1f", etaRange[1])+"]");
   TString* pdfNameEntriesNorm_zoom = new TString("track_Eta_primaryPurity"+dummyName[0]+"_@eta["+Form("%.1f", etaRange[0])+","+Form("%.1f", etaRange[1])+"]_zoom");
   TString* pdfNameEntriesNorm_split = new TString("track_Eta_splitPurity"+dummyName[0]+"_@eta["+Form("%.1f", etaRange[0])+","+Form("%.1f", etaRange[1])+"]");
   TString* pdfNameEntriesNorm_split_zoom = new TString("track_Eta_splitPurity"+dummyName[0]+"_@eta["+Form("%.1f", etaRange[0])+","+Form("%.1f", etaRange[1])+"]_zoom");
+  TString* pdfName_ratio = new TString("track_Eta_purity"+dummyName[0]+"_@eta["+Form("%.1f", etaRange[0])+","+Form("%.1f", etaRange[1])+"]_ratio");
 
   TString textContext(contextCustomTwoFields(*texDatasetsComparisonCommonDenominator, contextEtaRange(etaRange), ""));
 
@@ -1652,20 +1667,35 @@ void Draw_Purity_Eta_DatasetComparison(float* etaRange, bool useSplit) {
                                                     {0.94, 1}}}; // {{xmin, xmax}, {ymin, ymax}}
 
   if (divideSuccess == true) {
-    Draw_TH1_Histograms(H1D_trackEta_primaryPurity, DatasetsNames, nDatasets, textContext, pdfNameEntriesNorm, texEtaMC, texTrackPurity, texCollisionDataInfo, drawnWindowAuto, legendPlacementAuto, contextPlacementAuto, "efficiency");
-    Draw_TH1_Histograms(H1D_trackEta_primaryPurity, DatasetsNames, nDatasets, textContext, pdfNameEntriesNorm_zoom, texEtaMC, texTrackPurity, texCollisionDataInfo, drawnZoom_prim2, legendPlacementAuto, contextPlacementAuto, "efficiency");
+    Draw_TH1_Histograms(H1D_trackEta_primaryPurity, DatasetsNames, nDatasets, textContext, pdfNameEntriesNorm, texEtaMC, texTrackPurity, texCollisionDataInfo, drawnWindowAuto, legendPlacementAuto, contextPlacementAuto, "efficiency"+histDatasetComparisonStructure);
+    Draw_TH1_Histograms(H1D_trackEta_primaryPurity, DatasetsNames, nDatasets, textContext, pdfNameEntriesNorm_zoom, texEtaMC, texTrackPurity, texCollisionDataInfo, drawnZoom_prim2, legendPlacementAuto, contextPlacementAuto, "efficiency"+histDatasetComparisonStructure);
   }
   else {
-    cout << "Divide failed in Draw_Purity_Eta_DatasetComparison" << endl;
+    cout << "Divide failed in Draw_Purity_Eta_DatasetComparison 1" << endl;
   }
   if (divideSuccess_split == true) {
-    Draw_TH1_Histograms(H1D_trackEta_splitPurity, DatasetsNames, nDatasets, textContext, pdfNameEntriesNorm_split, texEtaMC, texTrackPurity, texCollisionDataInfo, drawnWindowAuto, legendPlacementAuto, contextPlacementAuto, "efficiency");
-    Draw_TH1_Histograms(H1D_trackEta_splitPurity, DatasetsNames, nDatasets, textContext, pdfNameEntriesNorm_split_zoom, texEtaMC, texTrackPurity, texCollisionDataInfo, drawnZoom_split, legendPlacementAuto, contextPlacementAuto, "efficiency");
+    Draw_TH1_Histograms(H1D_trackEta_splitPurity, DatasetsNames, nDatasets, textContext, pdfNameEntriesNorm_split, texEtaMC, texTrackPurity, texCollisionDataInfo, drawnWindowAuto, legendPlacementAuto, contextPlacementAuto, "efficiency"+histDatasetComparisonStructure);
+    Draw_TH1_Histograms(H1D_trackEta_splitPurity, DatasetsNames, nDatasets, textContext, pdfNameEntriesNorm_split_zoom, texEtaMC, texTrackPurity, texCollisionDataInfo, drawnZoom_split, legendPlacementAuto, contextPlacementAuto, "efficiency"+histDatasetComparisonStructure);
   }
   else {
-    cout << "Divide failed in Draw_Purity_Eta_DatasetComparison" << endl;
+    cout << "Divide failed in Draw_Purity_Eta_DatasetComparison 2" << endl;
+  }
+  
+  TString* pdfName_ratio_zoom = new TString("track_Eta_purity"+dummyName[0]+"_@eta["+Form("%.1f", etaRange[0])+","+Form("%.1f", etaRange[1])+"]_ratio_zoom");
+  if (divideSuccessRatio == true) {
+    if (histDatasetComparisonStructure.find("twoByTwoDatasetPairs") != std::string::npos) {
+      Draw_TH1_Histograms(H1D_trackEta_purity_ratios, DatasetsNamesPairRatio, nHistPairRatio, textContext, pdfName_ratio, texEtaMC, texRatio, texCollisionDataInfo, drawnWindowAuto, legendPlacementAuto, contextPlacementAuto, "zoomToOneLarge,ratioLine");
+      Draw_TH1_Histograms(H1D_trackEta_purity_ratios, DatasetsNamesPairRatio, nHistPairRatio, textContext, pdfName_ratio_zoom, texEtaMC, texRatio, texCollisionDataInfo, drawnWindowAuto, legendPlacementAuto, contextPlacementAuto, "zoomToOneLarge,ratioLine");
+    } else {
+    Draw_TH1_Histograms(H1D_trackEta_purity_ratios, DatasetsNames, nDatasets, textContext, pdfName_ratio, texEtaMC, texRatioDatasets, texCollisionDataInfo, drawnWindowAuto, legendPlacementAuto, contextPlacementAuto, "zoomToOneLarge,noMarkerFirst,ratioLine"+histDatasetComparisonStructure);
+    }
+  }
+  else {
+    cout << "divideSuccessRatio : " << divideSuccessRatio << endl;
+    cout << "Divide failed in Draw_Purity_Eta_DatasetComparison 3" << endl;
   }
 }
+
 
 
 void Draw_Purity_Phi_DatasetComparison(float* etaRange, bool useSplit) {
@@ -1720,6 +1750,27 @@ void Draw_Purity_Phi_DatasetComparison(float* etaRange, bool useSplit) {
     divideSuccess_split = H1D_trackPhi_splitPurity[iDataset]->Divide(H1D_trackPhi_primary[iDataset], H1D_splitPurity_denominator[iDataset]);
     }
   }
+  TH1D* H1D_trackPhi_purity_ratios[nDatasets];
+  TString DatasetsNamesPairRatio[nDatasets];
+  int nHistPairRatio = (int)nDatasets / 2;
+  bool divideSuccessRatio;
+  for(int iDataset = 0; iDataset < nDatasets; iDataset++){
+    if (histDatasetComparisonStructure.find("twoByTwoDatasetPairs") != std::string::npos) { //twoByTwoDatasetPairs assumes a Datasets array like so: {pair1_element1, pair1_element2, pair2_element1, pair2_element2..., pairN_element1, pairN_element2}
+      if (iDataset < nHistPairRatio) {
+          DatasetsNamesPairRatio[iDataset] = DatasetsNames[2*iDataset]+(TString)"/"+DatasetsNames[2*iDataset+1];
+          H1D_trackPhi_purity_ratios[iDataset] = (TH1D*)H1D_trackPhi_primaryPurity[2*iDataset]->Clone("H1D_trackPhi_primaryPurity_ratio"+Datasets[iDataset]+DatasetsNames[iDataset]);
+          H1D_trackPhi_purity_ratios[iDataset]->Reset("M");
+          cout << "Denominator integral (dataset "<< 2*iDataset+1 << ") = "<< H1D_trackPhi_primaryPurity[2*iDataset+1]->Integral()<< endl;
+          cout << "Nbins X Phi 2i = "<< H1D_trackPhi_primaryPurity[2*iDataset]->GetNbinsX()<< endl;
+          cout << "Nbins X Phi 2i+1 = "<< H1D_trackPhi_primaryPurity[2*iDataset+1]->GetNbinsX()<< endl;
+          divideSuccessRatio = H1D_trackPhi_purity_ratios[iDataset]->Divide(H1D_trackPhi_primaryPurity[2*iDataset], H1D_trackPhi_primaryPurity[2*iDataset+1]);
+      }
+    } else {
+        H1D_trackPhi_purity_ratios[iDataset] = (TH1D*)H1D_trackPhi_primaryPurity[iDataset]->Clone("H1D_trackPhi_primaryPurity_ratio"+Datasets[iDataset]+DatasetsNames[iDataset]);
+        H1D_trackPhi_purity_ratios[iDataset]->Reset("M");
+        divideSuccessRatio = H1D_trackPhi_purity_ratios[iDataset]->Divide(H1D_trackPhi_primaryPurity[iDataset], H1D_trackPhi_primaryPurity[0]);
+    }
+  }
 
   TString* pdfNameEntriesNorm = new TString("track_Phi_primaryPurity"+dummyName[0]+"_@eta["+Form("%.1f", etaRange[0])+","+Form("%.1f", etaRange[1])+"]");
   TString* pdfNameEntriesNorm_zoom = new TString("track_Phi_primaryPurity"+dummyName[0]+"_@eta["+Form("%.1f", etaRange[0])+","+Form("%.1f", etaRange[1])+"]_zoom");
@@ -1737,20 +1788,34 @@ void Draw_Purity_Phi_DatasetComparison(float* etaRange, bool useSplit) {
                                                     {0.94, 1}}}; // {{xmin, xmax}, {ymin, ymax}}
 
   if (divideSuccess == true) {
-    Draw_TH1_Histograms(H1D_trackPhi_primaryPurity, DatasetsNames, nDatasets, textContext, pdfNameEntriesNorm, texPhiRec, texTrackPurity, texCollisionDataInfo, drawnWindowAuto, legendPlacementAuto, contextPlacementAuto, "efficiency");
-    Draw_TH1_Histograms(H1D_trackPhi_primaryPurity, DatasetsNames, nDatasets, textContext, pdfNameEntriesNorm_zoom, texPhiRec, texTrackPurity, texCollisionDataInfo, drawnZoom_prim2, legendPlacementAuto, contextPlacementAuto, "efficiency");
+    Draw_TH1_Histograms(H1D_trackPhi_primaryPurity, DatasetsNames, nDatasets, textContext, pdfNameEntriesNorm, texPhiRec, texTrackPurity, texCollisionDataInfo, drawnWindowAuto, legendPlacementAuto, contextPlacementAuto, "efficiency"+histDatasetComparisonStructure);
+    Draw_TH1_Histograms(H1D_trackPhi_primaryPurity, DatasetsNames, nDatasets, textContext, pdfNameEntriesNorm_zoom, texPhiRec, texTrackPurity, texCollisionDataInfo, drawnZoom_prim2, legendPlacementAuto, contextPlacementAuto, "efficiency"+histDatasetComparisonStructure);
   }
   else {
     cout << "Divide failed in Draw_Purity_Phi_DatasetComparison" << endl;
   }
   if (useSplit == true) {
     if (divideSuccess_split == true) {
-      Draw_TH1_Histograms(H1D_trackPhi_splitPurity, DatasetsNames, nDatasets, textContext, pdfNameEntriesNorm_split, texPhiRec, texTrackPurity, texCollisionDataInfo, drawnWindowAuto, legendPlacementAuto, contextPlacementAuto, "efficiency");
-      Draw_TH1_Histograms(H1D_trackPhi_splitPurity, DatasetsNames, nDatasets, textContext, pdfNameEntriesNorm_split_zoom, texPhiRec, texTrackPurity, texCollisionDataInfo, drawnZoom_split, legendPlacementAuto, contextPlacementAuto, "efficiency");
+      Draw_TH1_Histograms(H1D_trackPhi_splitPurity, DatasetsNames, nDatasets, textContext, pdfNameEntriesNorm_split, texPhiRec, texTrackPurity, texCollisionDataInfo, drawnWindowAuto, legendPlacementAuto, contextPlacementAuto, "efficiency"+histDatasetComparisonStructure);
+      Draw_TH1_Histograms(H1D_trackPhi_splitPurity, DatasetsNames, nDatasets, textContext, pdfNameEntriesNorm_split_zoom, texPhiRec, texTrackPurity, texCollisionDataInfo, drawnZoom_split, legendPlacementAuto, contextPlacementAuto, "efficiency"+histDatasetComparisonStructure);
     }
     else {
       cout << "Divide failed in Draw_Purity_Phi_DatasetComparison" << endl;
     }
+  }
+  TString* pdfName_ratio = new TString("track_Phi_purity"+dummyName[0]+"_@eta["+Form("%.1f", etaRange[0])+","+Form("%.1f", etaRange[1])+"]_ratio");
+  TString* pdfName_ratio_zoom = new TString("track_Phi_purity"+dummyName[0]+"_@eta["+Form("%.1f", etaRange[0])+","+Form("%.1f", etaRange[1])+"]_ratio_zoom");
+  if (divideSuccessRatio == true) {
+    if (histDatasetComparisonStructure.find("twoByTwoDatasetPairs") != std::string::npos) {
+      Draw_TH1_Histograms(H1D_trackPhi_purity_ratios, DatasetsNamesPairRatio, nHistPairRatio, textContext, pdfName_ratio, texPhiRec, texRatio, texCollisionDataInfo, drawnWindowAuto, legendPlacementAuto, contextPlacementAuto, "zoomToOneLarge,ratioLine");
+      Draw_TH1_Histograms(H1D_trackPhi_purity_ratios, DatasetsNamesPairRatio, nHistPairRatio, textContext, pdfName_ratio_zoom, texPhiRec, texRatio, texCollisionDataInfo, drawnWindowAuto, legendPlacementAuto, contextPlacementAuto, "zoomToOneLarge,ratioLine");
+    } else {
+    Draw_TH1_Histograms(H1D_trackPhi_purity_ratios, DatasetsNames, nDatasets, textContext, pdfName_ratio, texPhiRec, texRatioDatasets, texCollisionDataInfo, drawnWindowAuto, legendPlacementAuto, contextPlacementAuto, "zoomToOneLarge,noMarkerFirst,ratioLine"+histDatasetComparisonStructure);
+    }
+  }
+  else {
+    cout << "divideSuccessRatio : " << divideSuccessRatio << endl;
+    cout << "Divide failed in Draw_Purity_Eta_DatasetComparison 3" << endl;
   }
 }
 
@@ -3160,125 +3225,6 @@ void Draw_PtResolution_Residuals(std::string options = "")
   // --- Sigma vs pT ---
   Draw_TH1_Histograms(H1D_ptRes_sigma_rebinned,DatasetsNames,nDatasets,textContext,pdfName_sigma,texPtX,texPtResSigma,texCollisionDataInfo,drawnWindowResidualSigma,legendPlacementResidual,contextPlacementAuto,"logx");
 }
-
-// void Draw_PtResolution_FromH2(std::string options = "")
-// {
-//     std::cout << "test1 " << std::endl;
-
-//     // =========================
-//     // Déclarations
-//     // =========================
-//     TH2D* H2D_ptRes[nDatasets];
-//     TH1D* H1D_ptRes_mean[nDatasets];
-//     TH1D* H1D_ptRes_sigma[nDatasets];
-
-//     // Fonction de fit (gaussienne)
-//     TF1* gaus = new TF1("gaus", "gaus", -0.3, 0.3);
-
-//     // =========================
-//     // Loop datasets
-//     // =========================
-//     std::cout << "test2 " << std::endl;
-
-//     for (int iDataset = 0; iDataset < nDatasets; iDataset++) {
-
-//         // --- Récupération du TH2 ---
-//         H2D_ptRes[iDataset] = (TH2D*) ((TH2D*)file_O2Analysis_list[iDataset]->Get(
-//             analysisWorkflow[iDataset] + "/h2_particle_pt_track_pt_deltaptoverparticlept"))->Clone(
-//                 "h2_ptRes_" + Datasets[iDataset] + DatasetsNames[iDataset]
-//         );
-
-//         // Sécurité
-//         if (!H2D_ptRes[iDataset]) {
-//             std::cout << "ERROR: H2 not found for dataset " << iDataset << std::endl;
-//             continue;
-//         }
-//         std::cout << "test3 " << std::endl;
-
-//         // --- Range en Y pour stabiliser le fit ---
-//         H2D_ptRes[iDataset]->GetYaxis()->SetRangeUser(-0.5, 0.5);
-
-//         // =========================
-// // --- Affichage des fits intermédiaires corrigé ---
-// // =========================
-// int firstX = 1;
-// int lastX  = 50;
-
-// for(int iX = firstX; iX <= lastX; iX++){
-    
-//     // Projection Y pour ce bin X
-//     TH1D* hY = H2D_ptRes[iDataset]->ProjectionY(
-//         TString::Format("hY_bin%d_dataset%d",iX,iDataset), iX, iX
-//     );
-    
-//     if (!hY) {
-//         std::cout << "WARNING: ProjectionY failed for bin " << iX << std::endl;
-//         continue;
-//     }
-
-//     // --- Création d'un canvas pour chaque slice ---
-//     TCanvas* cSlice = new TCanvas(
-//         TString::Format("cSlice_dataset%d_bin%d",iDataset,iX),
-//         TString::Format("Intermediate Fit: dataset %d, bin %d", iDataset, iX),
-//         600, 400
-//     );
-
-//     // --- Fit gaussien et affichage ---
-//     hY->Fit("gaus","R");   // R = respect de la range
-//     hY->SetTitle(TString::Format("Fit slice X bin %d", iX));
-//     hY->Draw();
-
-//     // Forcer l'affichage du canvas
-//     cSlice->Update();
-
-//     // Optionnel : pause pour voir le fit avant le suivant
-//     // gSystem->Sleep(200); // 200 ms, ajuste si nécessaire
-// }
-
-
-//         // =========================
-//         // --- FitSlicesY pour remplir les histos 1D ---
-//         // =========================
-//         H2D_ptRes[iDataset]->FitSlicesY(gaus, 0, -1, 0, "NR");
-
-//         // --- Récupération des histos produits ---
-//         H1D_ptRes_mean[iDataset] =
-//           (TH1D*) gDirectory->Get(TString(H2D_ptRes[iDataset]->GetName()) + "_1");
-
-//         H1D_ptRes_sigma[iDataset] =
-//           (TH1D*) gDirectory->Get(TString(H2D_ptRes[iDataset]->GetName()) + "_2");
-
-//         // --- Titres ---
-//         H1D_ptRes_mean[iDataset]->SetYTitle("Mean((p_{T}^{gen}-p_{T}^{track})/p_{T}^{track})");
-//         H1D_ptRes_sigma[iDataset]->SetYTitle("#sigma((p_{T}^{gen}-p_{T}^{track})/p_{T}^{track})");
-//         H1D_ptRes_sigma[iDataset]->SetXTitle("p_{T}^{gen} (GeV/c)");
-//     }
-
-//     // =========================
-//     // Drawing des résultats finaux
-//     // =========================
-//     TString textContext(contextTrackDatasetComp(""));
-
-//     TString* pdfName_mean  = new TString("track_PtResolution_mean");
-//     TString* pdfName_sigma = new TString("track_PtResolution_sigma");
-//     TString* texPtResMean  = new TString("Mean((p_{T}^{gen}-p_{T}^{track})/p_{T}^{track})");
-//     TString* texPtResSigma = new TString("#sigma((p_{T}^{gen}-p_{T}^{track})/p_{T}^{track})");
-
-//     const std::array<std::array<float, 2>, 2> drawnWindowAuto = {{{-999, -999}, {-999, -999}}};
-//     const std::array<std::array<float, 2>, 2> legendPlacementAuto = {{{0.6, 0.65}, {0.85, 0.85}}};
-
-//     // --- Mean vs pT ---
-//     Draw_TH1_Histograms(H1D_ptRes_mean, DatasetsNames, nDatasets,
-//                         textContext, pdfName_mean, texPtX, texPtResMean,
-//                         texCollisionDataInfo, drawnWindowAuto, legendPlacementAuto,
-//                         contextPlacementAuto, "logx");
-
-//     // --- Sigma vs pT ---
-//     Draw_TH1_Histograms(H1D_ptRes_sigma, DatasetsNames, nDatasets,
-//                         textContext, pdfName_sigma, texPtX, texPtResSigma,
-//                         texCollisionDataInfo, drawnWindowAuto, legendPlacementAuto,
-//                         contextPlacementAuto, "logx");
-// }
 
 
 

--- a/Tracks/TrackMcQC.C
+++ b/Tracks/TrackMcQC.C
@@ -109,9 +109,9 @@ void TrackMcQC() {
   float etaRange[2] = {-0.9, 0.9};
   float ptRange[2] = {0.15, 100};
   bool useLargeLegendWindow = false;
-  Draw_Efficiency_Pt_DatasetComparison(etaRange,useSplit, useLargeLegendWindow);
-  Draw_Efficiency_Eta_DatasetComparison(ptRange,useSplit);
-  Draw_Efficiency_Phi_DatasetComparison(ptRange, etaRange, useSplit);
+  // Draw_Efficiency_Pt_DatasetComparison(etaRange,useSplit, useLargeLegendWindow);
+  // Draw_Efficiency_Eta_DatasetComparison(ptRange,useSplit);
+  // Draw_Efficiency_Phi_DatasetComparison(ptRange, etaRange, useSplit);
 
   // Draw_Efficiency_Pt_ratio_etaNeg_etaPos_DatasetComparison(etaRange, useSplit);
   // // Draw_Efficiency_Phi_DatasetComparison_finerPhi(ptRange1, etaRange); // only works with very specific datasets created locally

--- a/Tracks/TrackMcQC.C
+++ b/Tracks/TrackMcQC.C
@@ -831,8 +831,8 @@ void Draw_Efficiency_Phi_DatasetComparison(float* ptRange, float* etaRange, bool
         DatasetsNamesPairRatio[iDataset] = DatasetsNames[2*iDataset]+(TString)"/"+DatasetsNames[2*iDataset+1];
         H1D_trackPhi_efficiency_ratios[iDataset] = (TH1D*)H1D_trackPhi_efficiency[2*iDataset]->Clone("H1D_trackPhi_efficiency_ratio"+Datasets[iDataset]+DatasetsNames[iDataset]);
         H1D_trackPhi_efficiency_ratios[iDataset]->Reset("M");
-        cout << "Nbins X PHI 2i = "<< H1D_trackPhi_efficiency[2*iDataset]->GetNbinsX()<< endl;
-        cout << "Nbins X PHI 2i+1 = "<< H1D_trackPhi_efficiency[2*iDataset+1]->GetNbinsX()<< endl;
+        // cout << "Nbins X PHI 2i = "<< H1D_trackPhi_efficiency[2*iDataset]->GetNbinsX()<< endl;
+        // cout << "Nbins X PHI 2i+1 = "<< H1D_trackPhi_efficiency[2*iDataset+1]->GetNbinsX()<< endl;
         divideSuccessRatio = H1D_trackPhi_efficiency_ratios[iDataset]->Divide(H1D_trackPhi_efficiency[2*iDataset], H1D_trackPhi_efficiency[2*iDataset+1]);
       }
     } else {
@@ -1612,8 +1612,8 @@ void Draw_Purity_Eta_DatasetComparison(float* etaRange, bool useSplit) {
 
     H1D_primaryPurity_denominator[iDataset] = (TH1D*)H1D_trackEta_primary[iDataset]->Clone("trackEta_primaryPurity_denominator"+Datasets[iDataset]+DatasetsNames[iDataset]);
     H1D_primaryPurity_denominator[iDataset]->Add(H1D_trackEta_secondary[iDataset],1.);
-    cout << "  - " << DatasetsNames[iDataset] << ":" << endl;
-    cout << "     eta eff #### tracks count = " << H1D_trackEta_primary[iDataset]->GetEntries() << ", part count = " << H1D_primaryPurity_denominator[iDataset]->GetEntries() << endl;
+    // cout << "  - " << DatasetsNames[iDataset] << ":" << endl;
+    // cout << "     eta eff #### tracks count = " << H1D_trackEta_primary[iDataset]->GetEntries() << ", part count = " << H1D_primaryPurity_denominator[iDataset]->GetEntries() << endl;
     divideSuccess = H1D_trackEta_primaryPurity[iDataset]->Divide(H1D_trackEta_primary[iDataset], H1D_primaryPurity_denominator[iDataset],1.,1.,"b");
 
 
@@ -1638,9 +1638,9 @@ void Draw_Purity_Eta_DatasetComparison(float* etaRange, bool useSplit) {
           DatasetsNamesPairRatio[iDataset] = DatasetsNames[2*iDataset]+(TString)"/"+DatasetsNames[2*iDataset+1];
           H1D_trackEta_purity_ratios[iDataset] = (TH1D*)H1D_trackEta_primaryPurity[2*iDataset]->Clone("H1D_trackEta_primaryPurity_ratio"+Datasets[iDataset]+DatasetsNames[iDataset]);
           H1D_trackEta_purity_ratios[iDataset]->Reset("M");
-          cout << "Denominator integral (dataset "<< 2*iDataset+1 << ") = "<< H1D_trackEta_primaryPurity[2*iDataset+1]->Integral()<< endl;
-          cout << "Nbins X ETA 2i = "<< H1D_trackEta_primaryPurity[2*iDataset]->GetNbinsX()<< endl;
-          cout << "Nbins X ETA 2i+1 = "<< H1D_trackEta_primaryPurity[2*iDataset+1]->GetNbinsX()<< endl;
+          // cout << "Denominator integral (dataset "<< 2*iDataset+1 << ") = "<< H1D_trackEta_primaryPurity[2*iDataset+1]->Integral()<< endl;
+          // cout << "Nbins X ETA 2i = "<< H1D_trackEta_primaryPurity[2*iDataset]->GetNbinsX()<< endl;
+          // cout << "Nbins X ETA 2i+1 = "<< H1D_trackEta_primaryPurity[2*iDataset+1]->GetNbinsX()<< endl;
           divideSuccessRatio = H1D_trackEta_purity_ratios[iDataset]->Divide(H1D_trackEta_primaryPurity[2*iDataset], H1D_trackEta_primaryPurity[2*iDataset+1]);
       }
     } else {
@@ -1760,9 +1760,9 @@ void Draw_Purity_Phi_DatasetComparison(float* etaRange, bool useSplit) {
           DatasetsNamesPairRatio[iDataset] = DatasetsNames[2*iDataset]+(TString)"/"+DatasetsNames[2*iDataset+1];
           H1D_trackPhi_purity_ratios[iDataset] = (TH1D*)H1D_trackPhi_primaryPurity[2*iDataset]->Clone("H1D_trackPhi_primaryPurity_ratio"+Datasets[iDataset]+DatasetsNames[iDataset]);
           H1D_trackPhi_purity_ratios[iDataset]->Reset("M");
-          cout << "Denominator integral (dataset "<< 2*iDataset+1 << ") = "<< H1D_trackPhi_primaryPurity[2*iDataset+1]->Integral()<< endl;
-          cout << "Nbins X Phi 2i = "<< H1D_trackPhi_primaryPurity[2*iDataset]->GetNbinsX()<< endl;
-          cout << "Nbins X Phi 2i+1 = "<< H1D_trackPhi_primaryPurity[2*iDataset+1]->GetNbinsX()<< endl;
+          // cout << "Denominator integral (dataset "<< 2*iDataset+1 << ") = "<< H1D_trackPhi_primaryPurity[2*iDataset+1]->Integral()<< endl;
+          // cout << "Nbins X Phi 2i = "<< H1D_trackPhi_primaryPurity[2*iDataset]->GetNbinsX()<< endl;
+          // cout << "Nbins X Phi 2i+1 = "<< H1D_trackPhi_primaryPurity[2*iDataset+1]->GetNbinsX()<< endl;
           divideSuccessRatio = H1D_trackPhi_purity_ratios[iDataset]->Divide(H1D_trackPhi_primaryPurity[2*iDataset], H1D_trackPhi_primaryPurity[2*iDataset+1]);
       }
     } else {

--- a/Tracks/TrackMcQC.C
+++ b/Tracks/TrackMcQC.C
@@ -90,6 +90,7 @@ void Draw_Phi_gen_DatasetComparison_H2CentVersion(std::string options);
 void Draw_Pt_tracksReco_fromEffWorkflow_DatasetComparison(float* etaRange, std::string options);
 void Draw_Eta_tracksReco_fromEffWorkflow_DatasetComparison(float* ptRange, std::string options);
 void Draw_Phi_tracksReco_fromEffWorkflow_DatasetComparison(float* ptRange, float* etaRange, std::string options);
+void Draw_PtResolution_Residuals(std::string options);
 
 /////////////////////////////////////////////////////
 ///////////////////// Main Macro ////////////////////
@@ -171,6 +172,7 @@ void TrackMcQC() {
   // Draw_Pt_gen_DatasetComparison_H2CentVersion("primaries,secondaries, ratio");
   // Draw_Eta_gen_DatasetComparison_H2CentVersion("primaries,secondaries, ratio");
   // Draw_Phi_gen_DatasetComparison_H2CentVersion("primaries,secondaries, ratio");
+  Draw_PtResolution_Residuals("ptRes_vs_pt");
 }
 /////////////////////////////////////////////////////
 /////////////////// Misc utilities //////////////////
@@ -703,6 +705,8 @@ void Draw_Efficiency_Eta_DatasetComparison(float* ptRange, bool useSplit) {
 
   // TString textContext(contextDatasetComp(""));
   TString textContext(contextCustomTwoFields(*texDatasetsComparisonCommonDenominator, contextPtRange(ptRange), ""));
+  std::array<std::array<float, 2>, 2> drawnZoom = {{{(float)H1D_trackEta_efficiency[0]->GetXaxis()->GetXmin(), (float)H1D_trackEta_efficiency[0]->GetXaxis()->GetXmax()}, 
+                                                    {0.6, 1}}}; // {{xmin, xmax}, {ymin, ymax}}
 
   if (divideSuccess == true) {
     Draw_TH1_Histograms(H1D_trackEta_efficiency, DatasetsNames, nDatasets, textContext, pdfNameEntriesNorm, texEtaMC, texTrackEfficiency, texCollisionDataInfo, drawnWindowAuto, legendPlacementEta, contextPlacementAuto, "efficiency"+histDatasetComparisonStructure);
@@ -855,7 +859,9 @@ void Draw_Efficiency_Phi_DatasetComparison(float* ptRange, float* etaRange, bool
 
   // TString textContext(contextDatasetComp(""));
   TString textContext(contextCustomTwoFields(*texDatasetsComparisonCommonDenominator, "#splitline{"+contextPtRange(ptRange)+"}{"+contextEtaRange(etaRange)+"}", ""));
-  std::array<std::array<float, 2>, 2> legendPlacementPhi = {{{0.55, 0.55}, {0.85, 0.85}}};
+  std::array<std::array<float, 2>, 2> legendPlacementPhi = {{{0.65, 0.65}, {0.85, 0.85}}};
+  std::array<std::array<float, 2>, 2> drawnZoom = {{{(float)H1D_trackPhi_efficiency[0]->GetXaxis()->GetXmin(), (float)H1D_trackPhi_efficiency[0]->GetXaxis()->GetXmax()}, 
+                                                    {0.45, 1}}}; // {{xmin, xmax}, {ymin, ymax}}
 
   std::array<std::array<float, 2>, 2> drawnWindowLogEff_zoom = {{{-999, -999}, {0.5, 1}}};
   std::array<std::array<float, 2>, 2> drawnWindowLogEffRatio_zoom = {{{-999, -999}, {0.8, 1.2}}};
@@ -1642,10 +1648,12 @@ void Draw_Purity_Eta_DatasetComparison(float* etaRange, bool useSplit) {
                                                     {0.9, 1}}}; // {{xmin, xmax}, {ymin, ymax}}
   std::array<std::array<float, 2>, 2> drawnZoom_split = {{{(float)H1D_trackEta_primaryPurity[0]->GetXaxis()->GetXmin(), (float)H1D_trackEta_primaryPurity[0]->GetXaxis()->GetXmax()}, 
                                                     {0.996, 1.002}}}; // {{xmin, xmax}, {ymin, ymax}}
+  std::array<std::array<float, 2>, 2> drawnZoom_prim2 = {{{(float)H1D_trackEta_primaryPurity[0]->GetXaxis()->GetXmin(), (float)H1D_trackEta_primaryPurity[0]->GetXaxis()->GetXmax()}, 
+                                                    {0.94, 1}}}; // {{xmin, xmax}, {ymin, ymax}}
 
   if (divideSuccess == true) {
     Draw_TH1_Histograms(H1D_trackEta_primaryPurity, DatasetsNames, nDatasets, textContext, pdfNameEntriesNorm, texEtaMC, texTrackPurity, texCollisionDataInfo, drawnWindowAuto, legendPlacementAuto, contextPlacementAuto, "efficiency");
-    Draw_TH1_Histograms(H1D_trackEta_primaryPurity, DatasetsNames, nDatasets, textContext, pdfNameEntriesNorm_zoom, texEtaMC, texTrackPurity, texCollisionDataInfo, drawnZoom_prim, legendPlacementAuto, contextPlacementAuto, "efficiency");
+    Draw_TH1_Histograms(H1D_trackEta_primaryPurity, DatasetsNames, nDatasets, textContext, pdfNameEntriesNorm_zoom, texEtaMC, texTrackPurity, texCollisionDataInfo, drawnZoom_prim2, legendPlacementAuto, contextPlacementAuto, "efficiency");
   }
   else {
     cout << "Divide failed in Draw_Purity_Eta_DatasetComparison" << endl;
@@ -1725,10 +1733,12 @@ void Draw_Purity_Phi_DatasetComparison(float* etaRange, bool useSplit) {
                                                     {0.9, 1}}}; // {{xmin, xmax}, {ymin, ymax}}
   std::array<std::array<float, 2>, 2> drawnZoom_split = {{{(float)H1D_trackPhi_primaryPurity[0]->GetXaxis()->GetXmin(), (float)H1D_trackPhi_primaryPurity[0]->GetXaxis()->GetXmax()}, 
                                                     {0.995, 1.005}}}; // {{xmin, xmax}, {ymin, ymax}}
+  std::array<std::array<float, 2>, 2> drawnZoom_prim2 = {{{(float)H1D_trackPhi_primaryPurity[0]->GetXaxis()->GetXmin(), (float)H1D_trackPhi_primaryPurity[0]->GetXaxis()->GetXmax()}, 
+                                                    {0.94, 1}}}; // {{xmin, xmax}, {ymin, ymax}}
 
   if (divideSuccess == true) {
     Draw_TH1_Histograms(H1D_trackPhi_primaryPurity, DatasetsNames, nDatasets, textContext, pdfNameEntriesNorm, texPhiRec, texTrackPurity, texCollisionDataInfo, drawnWindowAuto, legendPlacementAuto, contextPlacementAuto, "efficiency");
-    Draw_TH1_Histograms(H1D_trackPhi_primaryPurity, DatasetsNames, nDatasets, textContext, pdfNameEntriesNorm_zoom, texPhiRec, texTrackPurity, texCollisionDataInfo, drawnZoom_prim, legendPlacementAuto, contextPlacementAuto, "efficiency");
+    Draw_TH1_Histograms(H1D_trackPhi_primaryPurity, DatasetsNames, nDatasets, textContext, pdfNameEntriesNorm_zoom, texPhiRec, texTrackPurity, texCollisionDataInfo, drawnZoom_prim2, legendPlacementAuto, contextPlacementAuto, "efficiency");
   }
   else {
     cout << "Divide failed in Draw_Purity_Phi_DatasetComparison" << endl;
@@ -3021,4 +3031,254 @@ void Draw_Phi_tracksReco_fromEffWorkflow_DatasetComparison(float* ptRange, float
     }
   }
 }
+
+void Draw_PtResolution_Residuals(std::string options = "")
+{
+  // =========================
+  // Déclarations
+  // =========================
+  TH2D* H2D_ptRes[nDatasets];
+  TH1D* H1D_ptRes_mean[nDatasets];
+  TH1D* H1D_ptRes_mean_rebinned[nDatasets];
+  TH1D* H1D_ptRes_sigma[nDatasets];
+  TH1D* H1D_ptRes_sigma_rebinned[nDatasets];
+
+
+  // Fonction de fit (gaussienne)
+  TF1* gaus = new TF1("gaus", "gaus", -0.3, 0.3);
+
+  // =========================
+  // Loop datasets
+  // =========================
+
+  for (int iDataset = 0; iDataset < nDatasets; iDataset++) {
+
+    // --- Récupération du TH2 ---
+    H2D_ptRes[iDataset] =(TH2D*) ((TH2D*)file_O2Analysis_list[iDataset]->Get(analysisWorkflow[iDataset] +"/h2_particle_pt_track_pt_deltaptoverparticlept"))->Clone("h2_ptRes_" + Datasets[iDataset] + DatasetsNames[iDataset]);
+    
+    // Sécurité
+    if (!H2D_ptRes[iDataset]) {
+      std::cout << "ERROR: H2 not found for dataset " << iDataset << std::endl;
+      continue;
+    }
+    // --- Range en Y pour stabiliser le fit --- on garde uniquement les valeurs entre -0.5 et 0.5
+    H2D_ptRes[iDataset]->GetYaxis()->SetRangeUser(-0.5, 0.5);
+
+    // --- Fit slice par slice ---
+    H2D_ptRes[iDataset]->FitSlicesY(gaus, 0, -1, 0, "R");
+
+    // --- Récupération des histos produits ---
+    H1D_ptRes_mean[iDataset] =
+      (TH1D*) gDirectory->Get(
+        TString(H2D_ptRes[iDataset]->GetName()) + "_1"
+      );
+
+    H1D_ptRes_sigma[iDataset] =
+      (TH1D*) gDirectory->Get(
+        TString(H2D_ptRes[iDataset]->GetName()) + "_2"
+      );
+
+    // --- Titres ---
+    H1D_ptRes_mean[iDataset]->SetYTitle("Mean((p_{T}^{gen}-p_{T}^{track})/p_{T}^{track})");
+    H1D_ptRes_sigma[iDataset]->SetYTitle("#sigma((p_{T}^{gen}-p_{T}^{track})/p_{T}^{track})");
+    H1D_ptRes_sigma[iDataset]->SetXTitle("p_{T}^{gen} (GeV/c)");
+
+    // ===================== Advanced rebinning for ptRes =====================
+    std::vector<double> xbinsVector = GetTH1Bins(H1D_ptRes_sigma[iDataset]);
+    double* xbinsInitial = &xbinsVector[0];
+    double ptBinsNew[500]; // safe margin
+    int iBinNew = 0;
+    int iBinInitial = 0;
+    double binWidth = H1D_ptRes_sigma[iDataset]->GetXaxis()->GetBinWidth(1);
+    int increment;
+
+    while (iBinInitial < H1D_ptRes_sigma[iDataset]->GetNbinsX()) {
+        double pt = xbinsInitial[iBinInitial];
+
+        if (pt < 0.3) {
+            increment = 1;
+        } else if (pt < 25.0) {
+            // increment = 1;
+            increment = 1 + pt / binWidth / 8;
+        } else {
+            ptBinsNew[iBinNew++] = pt;    // left edge of large bin
+            ptBinsNew[iBinNew++] = 100.0; // right edge = 100
+            break;
+        }
+
+        ptBinsNew[iBinNew++] = pt;
+        iBinInitial += increment;
+    }
+
+    // security: last edge = 100
+    if (ptBinsNew[iBinNew-1] < 100.0) ptBinsNew[iBinNew++] = 100.0;
+
+    int nBinsNew = iBinNew - 1;
+
+    // ===== Rebin the histogram =====
+    H1D_ptRes_mean_rebinned[iDataset] = (TH1D*)H1D_ptRes_mean[iDataset]->Rebin(nBinsNew,"H1D_ptRes_mean_rebinned" + Datasets[iDataset] + DatasetsNames[iDataset],ptBinsNew);
+    H1D_ptRes_sigma_rebinned[iDataset] = (TH1D*)H1D_ptRes_sigma[iDataset]->Rebin(nBinsNew,"H1D_ptRes_sigma_rebinned" + Datasets[iDataset] + DatasetsNames[iDataset],ptBinsNew);
+
+    // ===== Optional: print bins for verification =====
+    std::cout << "=== Bins du ptRes_mean rebinned ===" << std::endl;
+    for (int i = 1; i <= H1D_ptRes_mean_rebinned[iDataset]->GetNbinsX(); i++) {
+        double xlow  = H1D_ptRes_mean_rebinned[iDataset]->GetBinLowEdge(i);
+        double xhigh = xlow + H1D_ptRes_mean_rebinned[iDataset]->GetBinWidth(i);
+        double content = H1D_ptRes_mean_rebinned[iDataset]->GetBinContent(i);
+        std::cout << "Bin " << i << ": [" << xlow << ", " << xhigh << "] -> " << content << std::endl;
+    }
+    std::cout << "=== Bins du ptRes_sigma rebinned ===" << std::endl;
+    for (int i = 1; i <= H1D_ptRes_sigma_rebinned[iDataset]->GetNbinsX(); i++) {
+        double xlow  = H1D_ptRes_sigma_rebinned[iDataset]->GetBinLowEdge(i);
+        double xhigh = xlow + H1D_ptRes_sigma_rebinned[iDataset]->GetBinWidth(i);
+        double content = H1D_ptRes_sigma_rebinned[iDataset]->GetBinContent(i);
+        std::cout << "Bin " << i << ": [" << xlow << ", " << xhigh << "] -> " << content << std::endl;
+    }
+
+  }
+
+  
+  // =========================
+  // Drawing
+  // =========================
+
+  TString textContext(contextTrackDatasetComp(""));
+
+  TString* pdfName_mean  = new TString("track_PtResolution_mean");
+  TString* pdfName_sigma = new TString("track_PtResolution_sigma");
+  TString* texPtResMean  = new TString("Mean((p_{T}^{gen}-p_{T}^{track})/p_{T}^{track})");
+  TString* texPtResSigma = new TString("#sigma((p_{T}^{gen}-p_{T}^{track})/p_{T}^{track})");
+
+
+  const std::array<std::array<float, 2>, 2> drawnWindowResidualMean = {{{-999, -999}, {-1.5, 1.5}}};
+  const std::array<std::array<float, 2>, 2> drawnWindowResidualSigma = {{{-999, -999}, {0, 0.4}}};
+  const std::array<std::array<float, 2>, 2> legendPlacementResidual = {{{0.17, 0.65}, {0.45, 0.75}}};
+
+  // --- Mean vs pT ---
+  Draw_TH1_Histograms(H1D_ptRes_mean_rebinned,DatasetsNames,nDatasets,textContext,pdfName_mean,texPtX,texPtResMean,texCollisionDataInfo,drawnWindowResidualMean,legendPlacementResidual,contextPlacementAuto,"logx");
+
+  // --- Sigma vs pT ---
+  Draw_TH1_Histograms(H1D_ptRes_sigma_rebinned,DatasetsNames,nDatasets,textContext,pdfName_sigma,texPtX,texPtResSigma,texCollisionDataInfo,drawnWindowResidualSigma,legendPlacementResidual,contextPlacementAuto,"logx");
+}
+
+// void Draw_PtResolution_FromH2(std::string options = "")
+// {
+//     std::cout << "test1 " << std::endl;
+
+//     // =========================
+//     // Déclarations
+//     // =========================
+//     TH2D* H2D_ptRes[nDatasets];
+//     TH1D* H1D_ptRes_mean[nDatasets];
+//     TH1D* H1D_ptRes_sigma[nDatasets];
+
+//     // Fonction de fit (gaussienne)
+//     TF1* gaus = new TF1("gaus", "gaus", -0.3, 0.3);
+
+//     // =========================
+//     // Loop datasets
+//     // =========================
+//     std::cout << "test2 " << std::endl;
+
+//     for (int iDataset = 0; iDataset < nDatasets; iDataset++) {
+
+//         // --- Récupération du TH2 ---
+//         H2D_ptRes[iDataset] = (TH2D*) ((TH2D*)file_O2Analysis_list[iDataset]->Get(
+//             analysisWorkflow[iDataset] + "/h2_particle_pt_track_pt_deltaptoverparticlept"))->Clone(
+//                 "h2_ptRes_" + Datasets[iDataset] + DatasetsNames[iDataset]
+//         );
+
+//         // Sécurité
+//         if (!H2D_ptRes[iDataset]) {
+//             std::cout << "ERROR: H2 not found for dataset " << iDataset << std::endl;
+//             continue;
+//         }
+//         std::cout << "test3 " << std::endl;
+
+//         // --- Range en Y pour stabiliser le fit ---
+//         H2D_ptRes[iDataset]->GetYaxis()->SetRangeUser(-0.5, 0.5);
+
+//         // =========================
+// // --- Affichage des fits intermédiaires corrigé ---
+// // =========================
+// int firstX = 1;
+// int lastX  = 50;
+
+// for(int iX = firstX; iX <= lastX; iX++){
+    
+//     // Projection Y pour ce bin X
+//     TH1D* hY = H2D_ptRes[iDataset]->ProjectionY(
+//         TString::Format("hY_bin%d_dataset%d",iX,iDataset), iX, iX
+//     );
+    
+//     if (!hY) {
+//         std::cout << "WARNING: ProjectionY failed for bin " << iX << std::endl;
+//         continue;
+//     }
+
+//     // --- Création d'un canvas pour chaque slice ---
+//     TCanvas* cSlice = new TCanvas(
+//         TString::Format("cSlice_dataset%d_bin%d",iDataset,iX),
+//         TString::Format("Intermediate Fit: dataset %d, bin %d", iDataset, iX),
+//         600, 400
+//     );
+
+//     // --- Fit gaussien et affichage ---
+//     hY->Fit("gaus","R");   // R = respect de la range
+//     hY->SetTitle(TString::Format("Fit slice X bin %d", iX));
+//     hY->Draw();
+
+//     // Forcer l'affichage du canvas
+//     cSlice->Update();
+
+//     // Optionnel : pause pour voir le fit avant le suivant
+//     // gSystem->Sleep(200); // 200 ms, ajuste si nécessaire
+// }
+
+
+//         // =========================
+//         // --- FitSlicesY pour remplir les histos 1D ---
+//         // =========================
+//         H2D_ptRes[iDataset]->FitSlicesY(gaus, 0, -1, 0, "NR");
+
+//         // --- Récupération des histos produits ---
+//         H1D_ptRes_mean[iDataset] =
+//           (TH1D*) gDirectory->Get(TString(H2D_ptRes[iDataset]->GetName()) + "_1");
+
+//         H1D_ptRes_sigma[iDataset] =
+//           (TH1D*) gDirectory->Get(TString(H2D_ptRes[iDataset]->GetName()) + "_2");
+
+//         // --- Titres ---
+//         H1D_ptRes_mean[iDataset]->SetYTitle("Mean((p_{T}^{gen}-p_{T}^{track})/p_{T}^{track})");
+//         H1D_ptRes_sigma[iDataset]->SetYTitle("#sigma((p_{T}^{gen}-p_{T}^{track})/p_{T}^{track})");
+//         H1D_ptRes_sigma[iDataset]->SetXTitle("p_{T}^{gen} (GeV/c)");
+//     }
+
+//     // =========================
+//     // Drawing des résultats finaux
+//     // =========================
+//     TString textContext(contextTrackDatasetComp(""));
+
+//     TString* pdfName_mean  = new TString("track_PtResolution_mean");
+//     TString* pdfName_sigma = new TString("track_PtResolution_sigma");
+//     TString* texPtResMean  = new TString("Mean((p_{T}^{gen}-p_{T}^{track})/p_{T}^{track})");
+//     TString* texPtResSigma = new TString("#sigma((p_{T}^{gen}-p_{T}^{track})/p_{T}^{track})");
+
+//     const std::array<std::array<float, 2>, 2> drawnWindowAuto = {{{-999, -999}, {-999, -999}}};
+//     const std::array<std::array<float, 2>, 2> legendPlacementAuto = {{{0.6, 0.65}, {0.85, 0.85}}};
+
+//     // --- Mean vs pT ---
+//     Draw_TH1_Histograms(H1D_ptRes_mean, DatasetsNames, nDatasets,
+//                         textContext, pdfName_mean, texPtX, texPtResMean,
+//                         texCollisionDataInfo, drawnWindowAuto, legendPlacementAuto,
+//                         contextPlacementAuto, "logx");
+
+//     // --- Sigma vs pT ---
+//     Draw_TH1_Histograms(H1D_ptRes_sigma, DatasetsNames, nDatasets,
+//                         textContext, pdfName_sigma, texPtX, texPtResSigma,
+//                         texCollisionDataInfo, drawnWindowAuto, legendPlacementAuto,
+//                         contextPlacementAuto, "logx");
+// }
+
+
 

--- a/Tracks/TrackQC.C
+++ b/Tracks/TrackQC.C
@@ -115,16 +115,16 @@ void TrackQC() {
 
 
   Draw_Pt_DatasetComparison("evtNorm");
-  Draw_Pt_DatasetComparison("entriesNorm");
+  // Draw_Pt_DatasetComparison("entriesNorm");
   for(int iPtBin = 0; iPtBin < nPtBins; iPtBin++){
     jetPtMinCut = jetPtMinCutArray[iPtBin];
     jetPtMaxCut = jetPtMinCutArray[iPtBin+1];
 
     float ptRange[2] = {jetPtMinCut, jetPtMaxCut};
     Draw_Eta_DatasetComparison(ptRange, "evtNorm");
-    Draw_Eta_DatasetComparison(ptRange, "entriesNorm");
+    // Draw_Eta_DatasetComparison(ptRange, "entriesNorm");
     Draw_Phi_DatasetComparison(ptRange, "evtNorm");
-    Draw_Phi_DatasetComparison(ptRange, "entriesNorm");
+    // Draw_Phi_DatasetComparison(ptRange, "entriesNorm");
 
   // Draw_Eta_DatasetComparison_trackSelComp();
   // Draw_Phi_DatasetComparison_trackSelComp();
@@ -373,9 +373,9 @@ void Draw_Pt_DatasetComparison(std::string options) {
   TString* pdfName_ratio_zoom = new TString("track_Pt_DataComp"+pdfNameNorm+"_ratio_zoom");
 
   std::array<std::array<float, 2>, 2> drawnWindowCustomRatio_zoom = {{{0.1, 100}, {0.9, 1.1}}}; // {{xmin, xmax}, {ymin, ymax}}
-  const std::array<std::array<float, 2>, 2> drawnWindowPt = {{{-999, -999}, {1e-8, 10}}}; // {{{xmin, xmax}, {ymin, ymax}}}
+  const std::array<std::array<float, 2>, 2> drawnWindowPt = {{{-999, -999}, {-999, -999}}}; // {{{xmin, xmax}, {ymin, ymax}}}
   const std::array<std::array<float, 2>, 2> legendPlacementPt = {{{0.7, 0.65}, {0.85, 0.85}}}; // {{{x1, y1}, {x2, y2}}}
-  const std::array<std::array<float, 2>, 2> drawnWindowPtRatio = {{{-999, -999}, {0, 2.65}}}; // {{{xmin, xmax}, {ymin, ymax}}}
+  const std::array<std::array<float, 2>, 2> drawnWindowPtRatio = {{{-999, -999}, {0.3, 1.8}}}; // {{{xmin, xmax}, {ymin, ymax}}}
   const std::array<std::array<float, 2>, 2> legendPlacementPtRatio = {{{0.17, 0.72}, {0.45, 0.81}}}; // {{{x1, y1}, {x2, y2}}}
 
 
@@ -484,7 +484,7 @@ void Draw_Eta_DatasetComparison(float* ptRange, std::string options) {
 
   std::array<std::array<float, 2>, 2> drawnWindowEta = {{{-1, 1}, {260, 390}}}; // {{xmin, xmax}, {ymin, ymax}}
   std::array<std::array<float, 2>, 2> drawnWindowEtaZoom = {{{-1, 1}, {-999, -999}}}; // {{xmin, xmax}, {ymin, ymax}}
-  std::array<std::array<float, 2>, 2> drawnWindowEtaTwoByTwoRatio = {{{-1, 1}, {0.9, 1.1}}}; // {{xmin, xmax}, {ymin, ymax}}
+  std::array<std::array<float, 2>, 2> drawnWindowEtaTwoByTwoRatio = {{{-1, 1}, {0.5, 1.3}}}; // {{xmin, xmax}, {ymin, ymax}}
   std::array<std::array<float, 2>, 2> legendPlacementCustom = {{{0.65, 0.65}, {0.85, 0.85}}}; // {{{x1, y1}, {x2, y2}}}
   std::array<std::array<float, 2>, 2> legendPlacementCustom2 = {{{0.2, 0.2}, {0.7, 0.38}}}; // {{{x1, y1}, {x2, y2}}}
 
@@ -591,8 +591,8 @@ void Draw_Phi_DatasetComparison(float* ptRange, std::string options) {
   TString* pdfName = new TString((TString)"track_Phi_DataComp_@pT["+Form("%03.0f", ptCutLow)+","+Form("%03.0f", ptCutHigh)+"]"+pdfNameNorm);
   TString* pdfName_ratio = new TString((TString)"track_Phi_DataComp_@pT["+Form("%03.0f", ptCutLow)+","+Form("%03.0f", ptCutHigh)+"]"+pdfNameNorm+"_ratio");
   
-  std::array<std::array<float, 2>, 2> drawnWindowEtaTwoByTwoRatio = {{{-1, 7}, {0.9, 1.5}}}; // {{xmin, xmax}, {ymin, ymax}}
-  std::array<std::array<float, 2>, 2> legendPlacementCustomRatio = {{{0.53, 0.65}, {0.58, 0.85}}}; // {{{x1, y1}, {x2, y2}}}
+  std::array<std::array<float, 2>, 2> drawnWindowEtaTwoByTwoRatio = {{{-1, 7}, {0.5, 1.7}}}; // {{xmin, xmax}, {ymin, ymax}}
+  std::array<std::array<float, 2>, 2> legendPlacementCustomRatio = {{{0.2, 0.2}, {0.5, 0.3}}}; // {{{x1, y1}, {x2, y2}}}
   std::array<std::array<float, 2>, 2> legendPlacementCustom = {{{0.65, 0.68}, {0.85, 0.85}}}; // {{{x1, y1}, {x2, y2}}}
   std::array<std::array<float, 2>, 2> drawnWindowEta = {{{-999, -999}, {-999, -999}}}; // {{xmin, xmax}, {ymin, ymax}}
 

--- a/Tracks/TrackQC.C
+++ b/Tracks/TrackQC.C
@@ -122,9 +122,7 @@ void TrackQC() {
 
     float ptRange[2] = {jetPtMinCut, jetPtMaxCut};
     Draw_Eta_DatasetComparison(ptRange, "evtNorm");
-    Draw_Eta_DatasetComparison(ptRange, "evtNorm");
     // Draw_Eta_DatasetComparison(ptRange, "entriesNorm");
-    Draw_Phi_DatasetComparison(ptRange, "evtNorm");
     Draw_Phi_DatasetComparison(ptRange, "evtNorm");
     // Draw_Phi_DatasetComparison(ptRange, "entriesNorm");
 
@@ -614,12 +612,10 @@ void Draw_Pt_CentralityComparison(int iDataset) {
   TH2D* H2D_trackPttrackCent;
   TH1D* H1D_trackPt[nCentralityBins];
   TH1D* H1D_trackPt_rebinned[nCentralityBins];
-  cout << "test1" << endl;
 
   if (trackHistsObsoleteVersion[iDataset]) {
     H2D_trackPttrackCent = (TH2D*)((TH2D*)file_O2Analysis_list[iDataset]->Get(analysisWorkflow[iDataset]+"/h2_centrality_track_pt"))->Clone("Draw_Pt_CentralityComparison"+Datasets[iDataset]+DatasetsNames[iDataset]);
     H2D_trackPttrackCent->Sumw2();
-    cout << "test2" << endl;
   } else {
     H3D_trackPttrackCent = (TH3D*)((TH3D*)file_O2Analysis_list[iDataset]->Get(analysisWorkflow[iDataset]+"/h3_centrality_track_pt_track_eta"))->Clone("Draw_Pt_CentralityComparison"+Datasets[iDataset]+DatasetsNames[iDataset]);
     H3D_trackPttrackCent->Sumw2();
@@ -629,7 +625,6 @@ void Draw_Pt_CentralityComparison(int iDataset) {
   TString CentralityLegend[nCentralityBins];
   std::stringstream ss;
   for(int iCentralityBin = 0; iCentralityBin < nCentralityBins; iCentralityBin++){
-    cout << "test3" << endl;
 
     if (trackHistsObsoleteVersion[iDataset]) {
       ibinCent_low = H2D_trackPttrackCent->GetXaxis()->FindBin(arrayCentralityBinning[iCentralityBin]);
@@ -642,15 +637,12 @@ void Draw_Pt_CentralityComparison(int iDataset) {
     }
       
     H1D_trackPt_rebinned[iCentralityBin] = (TH1D*)H1D_trackPt[iCentralityBin]->Rebin(1.,"trackPt_rebinned_"+Datasets[iDataset]+DatasetsNames[iDataset]+"_@cent["+Form("%.1d", ibinCent_low)+","+Form("%.1d", ibinCent_high)+"]");
-    cout << "test4" << endl;
 
     NormaliseYieldToNEvents(H1D_trackPt_rebinned[iCentralityBin], GetNEventsSelectedCentrality_JetFramework(file_O2Analysis_list[iDataset], analysisWorkflow[iDataset], arrayCentralityBinning[iCentralityBin], arrayCentralityBinning[iCentralityBin+1]));
-    cout << "test5" << endl;
     ss << "Cent " << arrayCentralityBinning[iCentralityBin] << " - " << arrayCentralityBinning[iCentralityBin+1] << " ";
     CentralityLegend[iCentralityBin] = (TString)ss.str();
     ss.str("");
     ss.clear();
-    cout << "test6" << endl;
   }
 
   TString* pdfName = new TString("track_CentralityComp_"+Datasets[iDataset]+DatasetsNames[iDataset]+"_Pt");

--- a/Tracks/TrackQC.C
+++ b/Tracks/TrackQC.C
@@ -239,11 +239,13 @@ void Draw_Pt_DatasetComparison(std::string options) {
 
   TH1D* H1D_trackPt[nDatasets];
   TH1D* H1D_trackPt_rebinned[nDatasets];
+
   TH1D* H1D_trackPt_rebinned_ratios[nDatasets];
 
   bool divideSuccess = false;
 
   double Nevents; 
+
   for(int iDataset = 0; iDataset < nDatasets; iDataset++){
 
     if (trackHistsObsoleteVersion[iDataset]) {
@@ -337,7 +339,6 @@ void Draw_Pt_DatasetComparison(std::string options) {
         NormaliseYieldToIntegral(H1D_trackPt_rebinned[iDataset]);
     }
   }
-
   TString DatasetsNamesPairRatio[nDatasets];
   int nHistPairRatio = (int)nDatasets / 2;;
   for(int iDataset = 0; iDataset < nDatasets; iDataset++){
@@ -372,8 +373,6 @@ void Draw_Pt_DatasetComparison(std::string options) {
   TString* pdfName_ratio_zoom = new TString("track_Pt_DataComp"+pdfNameNorm+"_ratio_zoom");
 
   std::array<std::array<float, 2>, 2> drawnWindowCustomRatio_zoom = {{{0.1, 100}, {0.9, 1.1}}}; // {{xmin, xmax}, {ymin, ymax}}
-
-
 
 
   Draw_TH1_Histograms(H1D_trackPt_rebinned, DatasetsNames, nDatasets, textContext, pdfName, texPtX, textYaxis, texCollisionDataInfo, drawnWindowPt, legendPlacementPt, contextPlacementAuto, "logx,logy"+histDatasetComparisonStructure);
@@ -485,6 +484,7 @@ void Draw_Eta_DatasetComparison(float* ptRange, std::string options) {
   std::array<std::array<float, 2>, 2> legendPlacementCustom2 = {{{0.2, 0.2}, {0.7, 0.38}}}; // {{{x1, y1}, {x2, y2}}}
 
 
+
   Draw_TH1_Histograms(H1D_trackEta_rebinned, DatasetsNames, nDatasets, textContext, pdfName, texEtaX, textYaxis, texCollisionDataInfo, drawnWindowEtaZoom, legendPlacementCustom, contextPlacementAuto, ""+histDatasetComparisonStructure);
   if (divideSuccess == true) {
     if (histDatasetComparisonStructure.find("twoByTwoDatasetPairs") != std::string::npos) {
@@ -591,9 +591,6 @@ void Draw_Phi_DatasetComparison(float* ptRange, std::string options) {
   std::array<std::array<float, 2>, 2> legendPlacementCustom = {{{0.65, 0.68}, {0.85, 0.85}}}; // {{{x1, y1}, {x2, y2}}}
   std::array<std::array<float, 2>, 2> drawnWindowEta = {{{-999, -999}, {1, 5}}}; // {{xmin, xmax}, {ymin, ymax}}
 
-
-
-
   Draw_TH1_Histograms(H1D_trackPhi_rebinned, DatasetsNames, nDatasets, textContext, pdfName, texPhiX, textYaxis, texCollisionDataInfo, drawnWindowEta, legendPlacementCustom, contextPlacementAuto, "histWithLine"+histDatasetComparisonStructure);
   if (divideSuccess == true) {
     if (histDatasetComparisonStructure.find("twoByTwoDatasetPairs") != std::string::npos) {
@@ -608,6 +605,7 @@ void Draw_Phi_DatasetComparison(float* ptRange, std::string options) {
 }
 
 void Draw_Pt_CentralityComparison(int iDataset) {
+
   TH3D* H3D_trackPttrackCent;
   TH2D* H2D_trackPttrackCent;
   TH1D* H1D_trackPt[nCentralityBins];
@@ -639,6 +637,7 @@ void Draw_Pt_CentralityComparison(int iDataset) {
     H1D_trackPt_rebinned[iCentralityBin] = (TH1D*)H1D_trackPt[iCentralityBin]->Rebin(1.,"trackPt_rebinned_"+Datasets[iDataset]+DatasetsNames[iDataset]+"_@cent["+Form("%.1d", ibinCent_low)+","+Form("%.1d", ibinCent_high)+"]");
 
     NormaliseYieldToNEvents(H1D_trackPt_rebinned[iCentralityBin], GetNEventsSelectedCentrality_JetFramework(file_O2Analysis_list[iDataset], analysisWorkflow[iDataset], arrayCentralityBinning[iCentralityBin], arrayCentralityBinning[iCentralityBin+1]));
+
     ss << "Cent " << arrayCentralityBinning[iCentralityBin] << " - " << arrayCentralityBinning[iCentralityBin+1] << " ";
     CentralityLegend[iCentralityBin] = (TString)ss.str();
     ss.str("");
@@ -1375,4 +1374,3 @@ void Draw_DcaXY_DatasetComp() {
   cout << "tesst3" << endl;
 
 }
-

--- a/Tracks/TrackQC.C
+++ b/Tracks/TrackQC.C
@@ -121,7 +121,9 @@ void TrackQC() {
 
     float ptRange[2] = {jetPtMinCut, jetPtMaxCut};
     Draw_Eta_DatasetComparison(ptRange, "evtNorm");
+    Draw_Eta_DatasetComparison(ptRange, "evtNorm");
     // Draw_Eta_DatasetComparison(ptRange, "entriesNorm");
+    Draw_Phi_DatasetComparison(ptRange, "evtNorm");
     Draw_Phi_DatasetComparison(ptRange, "evtNorm");
     // Draw_Phi_DatasetComparison(ptRange, "entriesNorm");
 
@@ -244,11 +246,12 @@ void Draw_Pt_DatasetComparison(std::string options) {
   bool divideSuccess = false;
 
   double Nevents; 
-
   for(int iDataset = 0; iDataset < nDatasets; iDataset++){
 
     if (trackHistsObsoleteVersion[iDataset]) {
+      cout<<"here1"<<endl;
       H2D_centrality_track[iDataset] = (TH2D*)((TH2D*)file_O2Analysis_list[iDataset]->Get(analysisWorkflow[iDataset]+"/h2_centrality_track_pt"))->Clone("Draw_Pt_DatasetComparison"+Datasets[iDataset]+DatasetsNames[iDataset]);
+      cout<<"here2"<<endl;
       H1D_trackPt[iDataset] = (TH1D*)H2D_centrality_track[iDataset]->ProjectionY("trackPt_"+Datasets[iDataset]+DatasetsNames[iDataset], iCollSystem == 0 ? 1 : 0, iCollSystem == 0 ? H2D_centrality_track[iDataset]->GetNbinsX() : -1, "e");
     } else {
       H3D_track[iDataset] = (TH3D*)((TH3D*)file_O2Analysis_list[iDataset]->Get(analysisWorkflow[iDataset]+"/h3_track_pt_track_eta_track_phi"))->Clone("Draw_Pt_DatasetComparison"+Datasets[iDataset]+DatasetsNames[iDataset]);
@@ -257,8 +260,7 @@ void Draw_Pt_DatasetComparison(std::string options) {
 
     // H1D_trackPt_rebinned[iDataset] = (TH1D*)H1D_trackPt[iDataset]->Rebin(2.,"trackPt_rebinned_"+Datasets[iDataset]+DatasetsNames[iDataset]);
     
-
-    int nBinsLogRough = 40;
+    int nBinsLogRough = 100;
     std::vector<double> O2H1DPtLogBinsVector = MakeVariableBinning_logarithmic(H1D_trackPt[iDataset], nBinsLogRough);
     int nBinsLogResult = O2H1DPtLogBinsVector.size()-1;
     // std::vector<double> O2H1DPtLogBinsVector = MakeVariableBinning_logarithmic(0.5, 100, nBinsLogRough);
@@ -421,14 +423,15 @@ void Draw_Eta_DatasetComparison(float* ptRange, std::string options) {
 
   std::array<std::array<float, 2>, 2> drawnWindowEta = {{{-1, 1}, {260, 390}}}; // {{xmin, xmax}, {ymin, ymax}}
   std::array<std::array<float, 2>, 2> drawnWindowEtaZoom = {{{-1, 1}, {-999, -999}}}; // {{xmin, xmax}, {ymin, ymax}}
-
+  std::array<std::array<float, 2>, 2> drawnWindowEtaTwoByTwoRatio = {{{-1, 1}, {1.02, 1.32}}}; // {{xmin, xmax}, {ymin, ymax}}
   std::array<std::array<float, 2>, 2> legendPlacementCustom = {{{0.2, 0.2}, {0.4, 0.45}}}; // {{{x1, y1}, {x2, y2}}}
+  std::array<std::array<float, 2>, 2> legendPlacementCustom1 = {{{0.2, 0.2}, {0.75, 0.40}}}; // {{{x1, y1}, {x2, y2}}}
 
 
   Draw_TH1_Histograms(H1D_trackEta_rebinned, DatasetsNames, nDatasets, textContext, pdfName, texEtaX, textYaxis, texCollisionDataInfo, drawnWindowAuto, legendPlacementCustom, contextPlacementAuto, ""+histDatasetComparisonStructure);
   if (divideSuccess == true) {
     if (histDatasetComparisonStructure.find("twoByTwoDatasetPairs") != std::string::npos) {
-      Draw_TH1_Histograms(H1D_trackEta_rebinned_ratios, DatasetsNamesPairRatio, nHistPairRatio, textContext, pdfName_ratio, texEtaX, texRatio, texCollisionDataInfo, drawnWindowAuto, legendPlacementAuto, contextPlacementAuto, ",zoomToOneExtra");
+      Draw_TH1_Histograms(H1D_trackEta_rebinned_ratios, DatasetsNamesPairRatio, nHistPairRatio, textContext, pdfName_ratio, texEtaX, texRatio, texCollisionDataInfo, drawnWindowEtaTwoByTwoRatio, legendPlacementCustom1, contextPlacementAuto, ",zoomToOneExtra");
     } else {
       Draw_TH1_Histograms(H1D_trackEta_rebinned_ratios, DatasetsNames, nDatasets, textContext, pdfName_ratio, texEtaX, texRatioDatasets, texCollisionDataInfo, drawnWindowAuto, legendPlacementAuto, contextPlacementAuto, "noMarkerFirst"+histDatasetComparisonStructure);
       Draw_TH1_Histograms(H1D_trackEta_rebinned_ratios, DatasetsNames, nDatasets, textContext, pdfName_ratio_zoom, texEtaX, texRatioDatasets, texCollisionDataInfo, drawnWindowAuto, legendPlacementAuto, contextPlacementAuto, "noMarkerFirst,zoomToOneMedium2"+histDatasetComparisonStructure);
@@ -527,11 +530,13 @@ void Draw_Phi_DatasetComparison(float* ptRange, std::string options) {
   TString* pdfName_ratio = new TString((TString)"track_Phi_DataComp_@pT["+Form("%03.0f", ptCutLow)+","+Form("%03.0f", ptCutHigh)+"]"+pdfNameNorm+"_ratio");
   
   std::array<std::array<float, 2>, 2> legendPlacementCustom = {{{0.2, 0.2}, {0.4, 0.45}}}; // {{{x1, y1}, {x2, y2}}}
+  std::array<std::array<float, 2>, 2> drawnWindowEtaTwoByTwoRatio = {{{-1, 7}, {0.95, 1.5}}}; // {{xmin, xmax}, {ymin, ymax}}
+
 
   Draw_TH1_Histograms(H1D_trackPhi_rebinned, DatasetsNames, nDatasets, textContext, pdfName, texPhiX, textYaxis, texCollisionDataInfo, drawnWindowAuto, legendPlacementCustom, contextPlacementAuto, "histWithLine"+histDatasetComparisonStructure);
   if (divideSuccess == true) {
     if (histDatasetComparisonStructure.find("twoByTwoDatasetPairs") != std::string::npos) {
-      Draw_TH1_Histograms(H1D_trackPhi_rebinned_ratios, DatasetsNamesPairRatio, nHistPairRatio, textContext, pdfName_ratio, texPhiX, texRatio, texCollisionDataInfo, drawnWindowAuto, legendPlacementAuto, contextPlacementAuto, "zoomToOneExtraExtra");
+      Draw_TH1_Histograms(H1D_trackPhi_rebinned_ratios, DatasetsNamesPairRatio, nHistPairRatio, textContext, pdfName_ratio, texPhiX, texRatio, texCollisionDataInfo, drawnWindowEtaTwoByTwoRatio, legendPlacementAuto, contextPlacementAuto, "zoomToOneExtraExtra");
     } else {
       Draw_TH1_Histograms(H1D_trackPhi_rebinned_ratios, DatasetsNames, nDatasets, textContext, pdfName_ratio, texPhiX, texRatioDatasets, texCollisionDataInfo, drawnWindowAuto, legendPlacementCustom, contextPlacementAuto, "noMarkerFirst"+histDatasetComparisonStructure);
     }

--- a/Tracks/TrackQC.C
+++ b/Tracks/TrackQC.C
@@ -114,17 +114,17 @@ void TrackQC() {
   float jetPtMinCutArray[nPtBins+1] = {0.15, 100};
 
 
-  // Draw_Pt_DatasetComparison("evtNorm");
-  // Draw_Pt_DatasetComparison("entriesNorm");
+  Draw_Pt_DatasetComparison("evtNorm");
+  Draw_Pt_DatasetComparison("entriesNorm");
   for(int iPtBin = 0; iPtBin < nPtBins; iPtBin++){
     jetPtMinCut = jetPtMinCutArray[iPtBin];
     jetPtMaxCut = jetPtMinCutArray[iPtBin+1];
 
     float ptRange[2] = {jetPtMinCut, jetPtMaxCut};
     Draw_Eta_DatasetComparison(ptRange, "evtNorm");
-    // Draw_Eta_DatasetComparison(ptRange, "entriesNorm");
+    Draw_Eta_DatasetComparison(ptRange, "entriesNorm");
     Draw_Phi_DatasetComparison(ptRange, "evtNorm");
-    // Draw_Phi_DatasetComparison(ptRange, "entriesNorm");
+    Draw_Phi_DatasetComparison(ptRange, "entriesNorm");
 
   // Draw_Eta_DatasetComparison_trackSelComp();
   // Draw_Phi_DatasetComparison_trackSelComp();
@@ -373,6 +373,11 @@ void Draw_Pt_DatasetComparison(std::string options) {
   TString* pdfName_ratio_zoom = new TString("track_Pt_DataComp"+pdfNameNorm+"_ratio_zoom");
 
   std::array<std::array<float, 2>, 2> drawnWindowCustomRatio_zoom = {{{0.1, 100}, {0.9, 1.1}}}; // {{xmin, xmax}, {ymin, ymax}}
+  const std::array<std::array<float, 2>, 2> drawnWindowPt = {{{-999, -999}, {1e-8, 10}}}; // {{{xmin, xmax}, {ymin, ymax}}}
+  const std::array<std::array<float, 2>, 2> legendPlacementPt = {{{0.7, 0.65}, {0.85, 0.85}}}; // {{{x1, y1}, {x2, y2}}}
+  const std::array<std::array<float, 2>, 2> drawnWindowPtRatio = {{{-999, -999}, {0, 2.65}}}; // {{{xmin, xmax}, {ymin, ymax}}}
+  const std::array<std::array<float, 2>, 2> legendPlacementPtRatio = {{{0.17, 0.72}, {0.45, 0.81}}}; // {{{x1, y1}, {x2, y2}}}
+
 
 
   Draw_TH1_Histograms(H1D_trackPt_rebinned, DatasetsNames, nDatasets, textContext, pdfName, texPtX, textYaxis, texCollisionDataInfo, drawnWindowPt, legendPlacementPt, contextPlacementAuto, "logx,logy"+histDatasetComparisonStructure);
@@ -478,7 +483,7 @@ void Draw_Eta_DatasetComparison(float* ptRange, std::string options) {
   TString* pdfName_ratio_zoom2 = new TString((TString)"track_Eta_DataComp_@pT["+Form("%03.0f", ptCutLow)+","+Form("%03.0f", ptCutHigh)+"]"+pdfNameNorm+"_ratio_zoom2");
 
   std::array<std::array<float, 2>, 2> drawnWindowEta = {{{-1, 1}, {260, 390}}}; // {{xmin, xmax}, {ymin, ymax}}
-  std::array<std::array<float, 2>, 2> drawnWindowEtaZoom = {{{-1, 1}, {25, 30}}}; // {{xmin, xmax}, {ymin, ymax}}
+  std::array<std::array<float, 2>, 2> drawnWindowEtaZoom = {{{-1, 1}, {-999, -999}}}; // {{xmin, xmax}, {ymin, ymax}}
   std::array<std::array<float, 2>, 2> drawnWindowEtaTwoByTwoRatio = {{{-1, 1}, {0.9, 1.1}}}; // {{xmin, xmax}, {ymin, ymax}}
   std::array<std::array<float, 2>, 2> legendPlacementCustom = {{{0.65, 0.65}, {0.85, 0.85}}}; // {{{x1, y1}, {x2, y2}}}
   std::array<std::array<float, 2>, 2> legendPlacementCustom2 = {{{0.2, 0.2}, {0.7, 0.38}}}; // {{{x1, y1}, {x2, y2}}}
@@ -589,7 +594,7 @@ void Draw_Phi_DatasetComparison(float* ptRange, std::string options) {
   std::array<std::array<float, 2>, 2> drawnWindowEtaTwoByTwoRatio = {{{-1, 7}, {0.9, 1.5}}}; // {{xmin, xmax}, {ymin, ymax}}
   std::array<std::array<float, 2>, 2> legendPlacementCustomRatio = {{{0.53, 0.65}, {0.58, 0.85}}}; // {{{x1, y1}, {x2, y2}}}
   std::array<std::array<float, 2>, 2> legendPlacementCustom = {{{0.65, 0.68}, {0.85, 0.85}}}; // {{{x1, y1}, {x2, y2}}}
-  std::array<std::array<float, 2>, 2> drawnWindowEta = {{{-999, -999}, {1, 5}}}; // {{xmin, xmax}, {ymin, ymax}}
+  std::array<std::array<float, 2>, 2> drawnWindowEta = {{{-999, -999}, {-999, -999}}}; // {{xmin, xmax}, {ymin, ymax}}
 
   Draw_TH1_Histograms(H1D_trackPhi_rebinned, DatasetsNames, nDatasets, textContext, pdfName, texPhiX, textYaxis, texCollisionDataInfo, drawnWindowEta, legendPlacementCustom, contextPlacementAuto, "histWithLine"+histDatasetComparisonStructure);
   if (divideSuccess == true) {


### PR DESCRIPTION
Modifications in :

JetQC.C : Mainly adding ratio plots when 'twoByTwoDatasetPairs' is selected (it was missing and I needed it to plot ratios, not for QC2024 but for another QC) + some legends & drawnWindow

TrackMcQC.C : New function created 'Draw_PtResolution_Residuals' (at the end of the code) for pt resolution when using residual (it gives the mean & sigma plots) + some legends & drawnWindow

TrackQC.C : Adding the rebbining for high pt in 'Draw_Pt_DatasetComparison' + some legends & drawnWindow


